### PR TITLE
Release 1.6.1 (versionCode 21) + build-script fix

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Pill O-Clock",
     "slug": "pill-o-clock",
-    "version": "1.5.0",
+    "version": "1.6.1",
     "scheme": "pilloclock",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -31,7 +31,7 @@
     },
     "android": {
       "package": "com.pilloclock.app",
-      "versionCode": 1,
+      "versionCode": 21,
       "adaptiveIcon": {
         "backgroundColor": "#f0f6ff",
         "foregroundImage": "./assets/android-icon-foreground.png",

--- a/scripts/build-android.mjs
+++ b/scripts/build-android.mjs
@@ -49,9 +49,13 @@ console.log("Sentry auth token found. Source maps will be uploaded.\n");
 
 // ─── Run Gradle bundleRelease ───────────────────────────────────────────────
 const androidDir = resolve("android");
+// Use an absolute, quoted path to the wrapper. A bare "gradlew.bat" relies on
+// cmd.exe searching the current directory, which fails when Windows has
+// NoDefaultCurrentDirectoryInExePath set.
+const gradlew = join(androidDir, "gradlew.bat");
 
 try {
-  execSync("gradlew.bat bundleRelease --console=plain", {
+  execSync(`"${gradlew}" bundleRelease --console=plain`, {
     cwd: androidDir,
     stdio: "inherit",
     env: {


### PR DESCRIPTION
## Release 1.6.1 (versionCode 21) + build-script fix

### Release
Bumps the app to **versionName 1.6.1 / versionCode 21** and records it in `app.json` (the tracked source a fresh `expo prebuild` reads). This build was published to the **Play Store internal track** via the Google Play Developer API (service account), superseding the prior internal release `20` (1.6.0). It contains the audit remediation (Sprints 1–3) and the full UX pass (I1–I13).

> The local `android/app/build.gradle` is gitignored and was bumped in lockstep for the signed build.

### Build-script fix
`scripts/build-android.mjs` invoked `execSync("gradlew.bat …")`, which relied on cmd.exe searching the current directory — that fails on Windows when `NoDefaultCurrentDirectoryInExePath` is set (`'gradlew.bat' is not recognized`), so `npm run build:android` couldn't run. It now invokes the wrapper by its absolute, quoted path.

Verified: `node --check` passes; the absolute-path invocation was confirmed to resolve gradle (`Gradle 8.14.3`) via the same `execSync` mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
