### PR TITLE
fix(alarm): shortService FGS + re-remind loop (drops Play FGS declaration)

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Pill O-Clock",
     "slug": "pill-o-clock",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "scheme": "pilloclock",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -31,7 +31,7 @@
     },
     "android": {
       "package": "com.pilloclock.app",
-      "versionCode": 21,
+      "versionCode": 22,
       "adaptiveIcon": {
         "backgroundColor": "#f0f6ff",
         "foregroundImage": "./assets/android-icon-foreground.png",
@@ -46,7 +46,6 @@
         "android.permission.POST_NOTIFICATIONS",
         "android.permission.WAKE_LOCK",
         "android.permission.FOREGROUND_SERVICE",
-        "android.permission.FOREGROUND_SERVICE_ALARM",
         "android.permission.USE_FULL_SCREEN_INTENT",
         "android.permission.ACCESS_FINE_LOCATION",
         "android.permission.ACCESS_COARSE_LOCATION"

--- a/modules/expo-alarm/android/src/main/AndroidManifest.xml
+++ b/modules/expo-alarm/android/src/main/AndroidManifest.xml
@@ -4,8 +4,14 @@
   <!-- Required for playing audio + waking the screen -->
   <uses-permission android:name="android.permission.WAKE_LOCK" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-  <!-- API 34+: foreground service type for audio playback -->
-  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+  <!--
+    API 34+: the alarm runs as a "shortService" foreground service. This type
+    needs no type-specific permission (only FOREGROUND_SERVICE) and is exempt
+    from Google Play's foreground-service declaration + demo-video requirement,
+    unlike FOREGROUND_SERVICE_MEDIA_PLAYBACK. Trade-off: the system caps a
+    short service at ~3 min, after which onTimeout() silences the alarm and
+    leaves a tap-to-open reminder (see AlarmAudioService).
+  -->
   <!-- Show alarm screen above the lock screen / other apps -->
   <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
   <!-- Re-arm alarms after a device reboot (AlarmManager clears them on boot) -->
@@ -24,12 +30,13 @@
     <!--
       AlarmAudioService: ForegroundService that plays alarm.wav on STREAM_ALARM
       and displays the fullScreenIntent notification.
-      foregroundServiceType="mediaPlayback" required on API 34+.
+      foregroundServiceType="shortService" on API 34+ (no Play FGS declaration
+      required; system-capped at ~3 min — handled by onTimeout()).
     -->
     <service
       android:name="expo.modules.alarm.AlarmAudioService"
       android:exported="false"
-      android:foregroundServiceType="mediaPlayback" />
+      android:foregroundServiceType="shortService" />
 
     <!--
       AlarmActionReceiver: handles Take / Snooze / Skip quick-action button

--- a/modules/expo-alarm/android/src/main/java/expo/modules/alarm/AlarmAudioService.kt
+++ b/modules/expo-alarm/android/src/main/java/expo/modules/alarm/AlarmAudioService.kt
@@ -1,5 +1,6 @@
 package expo.modules.alarm
 
+import android.app.AlarmManager
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -32,6 +33,14 @@ import androidx.core.app.NotificationCompat
  *  5. Exposes Take / Snooze / Skip quick-action buttons on the notification.
  *  6. If the user swipes the notification away (Android 14+), silences the
  *     alarm and posts a quiet reminder so the dose is not forgotten.
+ *  7. If a ring ends without the dose being logged (timeout or swipe), re-arms
+ *     itself a few minutes later (up to MAX_REMINDERS) so an ignored dose keeps
+ *     nudging until it is marked Taken/Skipped — see scheduleReRemind().
+ *
+ * Runs as a FOREGROUND_SERVICE_TYPE_SHORT_SERVICE on API 34+. This type is
+ * exempt from Google Play's foreground-service declaration (unlike
+ * mediaPlayback) but the system caps it at ~3 min; onTimeout() then silences
+ * the alarm and leaves a tap-to-open reminder so the dose is never dropped.
  *
  * Stopped by broadcasting ACTION_STOP (sent from ExpoAlarmModule.stopAlarm()
  * or from AlarmActionReceiver when a button is tapped).
@@ -59,6 +68,8 @@ class AlarmAudioService : Service() {
     const val EXTRA_SCHEDULED_TIME  = "scheduledTime"
     const val EXTRA_MEDICATION_NAME = "medicationName"
     const val EXTRA_DOSE            = "dose"
+    /** How many times THIS dose has already been auto-re-reminded (0 = first ring). */
+    const val EXTRA_REPEAT_COUNT   = "repeatCount"
     /** Value passed in the notification action extras — "taken" | "snooze" | "skipped". */
     const val EXTRA_ACTION          = "alarmAction"
 
@@ -66,6 +77,18 @@ class AlarmAudioService : Service() {
     const val ACTION_VALUE_TAKEN  = "taken"
     const val ACTION_VALUE_SNOOZE = "snooze"
     const val ACTION_VALUE_SKIP   = "skipped"
+
+    // ── Re-remind loop (audit: missed-dose safety) ──────────────────────────
+    // When a ring ends without the user acting (shortService ~3-min timeout OR
+    // a swipe-away), the alarm re-arms itself this many minutes later, up to
+    // MAX_REMINDERS times, so an ignored dose keeps nudging — mirroring the
+    // "remind until confirmed" behaviour of comparable apps. The loop stops the
+    // instant the dose is logged Taken/Skipped (the app calls cancelAlarm, which
+    // targets the same requestCode) or Snoozed (the app re-schedules afresh).
+    /** Minutes between an unanswered ring ending and the next auto-reminder. */
+    private const val REMIND_INTERVAL_MIN = 5
+    /** Max auto-reminders per dose before we stop and leave only a silent reminder. */
+    private const val MAX_REMINDERS       = 6
 
     private const val ALARM_NOTIF_ID    = 8471   // must not clash with expo-notifications
     private const val SILENT_NOTIF_ID   = 8472   // silent reminder after dismiss
@@ -80,13 +103,16 @@ class AlarmAudioService : Service() {
   private var mediaPlayer: MediaPlayer? = null
   private var wakeLock: PowerManager.WakeLock? = null
 
-  // Cached payload so the dismiss handler can post a silent reminder
-  // without needing access to the original Intent extras.
+  // Cached payload so the dismiss handler can post a silent reminder and the
+  // re-remind loop can re-arm without access to the original Intent extras.
   private var cachedScheduleId    = ""
+  private var cachedMedicationId  = ""
   private var cachedScheduledDate = ""
   private var cachedScheduledTime = ""
   private var cachedMedName       = ""
   private var cachedDose          = ""
+  /** How many times this dose has already auto-re-reminded (0 = first ring). */
+  private var cachedRepeatCount   = 0
 
   /**
    * Listens for ACTION_STOP — sent by ExpoAlarmModule.stopAlarm() and by
@@ -101,11 +127,13 @@ class AlarmAudioService : Service() {
   /**
    * Listens for ACTION_DISMISS — sent by the notification deleteIntent when the
    * user swipes the alarm notification away on Android 14+.
-   * Silences the alarm and posts a quiet tap-to-open reminder.
+   * Silences the alarm, posts a quiet tap-to-open reminder, and (since a swipe
+   * is not the same as logging the dose) re-arms the next auto-reminder.
    */
   private val dismissReceiver = object : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-      postSilentReminder()
+      runCatching { postSilentReminder() }
+      runCatching { scheduleReRemind() }
       stopSelf()
     }
   }
@@ -153,7 +181,7 @@ class AlarmAudioService : Service() {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
         startForeground(ALARM_NOTIF_ID,
           NotificationCompat.Builder(this, ALARM_CHANNEL_ID).build(),
-          ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
+          ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE)
       } else {
         startForeground(ALARM_NOTIF_ID,
           NotificationCompat.Builder(this, ALARM_CHANNEL_ID).build())
@@ -172,13 +200,21 @@ class AlarmAudioService : Service() {
     val scheduledTime = intent.getStringExtra(EXTRA_SCHEDULED_TIME)  ?: ""
     val medName       = intent.getStringExtra(EXTRA_MEDICATION_NAME) ?: ""
     val dose          = intent.getStringExtra(EXTRA_DOSE)            ?: ""
+    val repeatCount   = intent.getIntExtra(EXTRA_REPEAT_COUNT, 0)
 
-    // Cache for dismiss handler
+    // Cache for the dismiss handler and the re-remind loop
     cachedScheduleId    = scheduleId
+    cachedMedicationId  = medicationId
     cachedScheduledDate = scheduledDate
     cachedScheduledTime = scheduledTime
     cachedMedName       = medName
     cachedDose          = dose
+    cachedRepeatCount   = repeatCount
+
+    // A fresh ring supersedes any lingering silent reminder from a prior cycle,
+    // so at most one notification for this dose is ever visible at once.
+    (getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)
+      .cancel(SILENT_NOTIF_ID)
 
     // ── Wake the display ─────────────────────────────────────────────────────
     val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
@@ -193,7 +229,7 @@ class AlarmAudioService : Service() {
     val notification = buildAlarmNotification(scheduleId, medicationId, scheduledDate, scheduledTime, medName, dose)
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-      startForeground(ALARM_NOTIF_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
+      startForeground(ALARM_NOTIF_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE)
     } else {
       startForeground(ALARM_NOTIF_ID, notification)
     }
@@ -208,6 +244,84 @@ class AlarmAudioService : Service() {
     playAlarm()
 
     return START_NOT_STICKY
+  }
+
+  /**
+   * Android 14 (API 34) "shortService" timeout. The system calls this ~3 min
+   * after the service enters the foreground; we MUST stop the service promptly
+   * or the OS throws ForegroundServiceDidNotStopInTimeException and crashes the
+   * process. Instead of dropping the dose silently, we silence the alarm audio
+   * and leave a quiet tap-to-open reminder so the medication stays visible in
+   * the shade — mirroring the swipe-to-dismiss behaviour.
+   */
+  override fun onTimeout(startId: Int) {
+    handleShortServiceTimeout()
+  }
+
+  /** API 35+ overload of onTimeout — same handling. */
+  override fun onTimeout(startId: Int, fgsType: Int) {
+    handleShortServiceTimeout()
+  }
+
+  private fun handleShortServiceTimeout() {
+    Log.i(TAG, "shortService timeout reached — silencing alarm, posting reminder")
+    runCatching { postSilentReminder() }
+    runCatching { scheduleReRemind() }
+    stopSelf()
+  }
+
+  /**
+   * Re-arms this dose's alarm [REMIND_INTERVAL_MIN] minutes from now so an
+   * unanswered dose keeps nudging, up to [MAX_REMINDERS] times. Uses the SAME
+   * deterministic PendingIntent (requestCode = scheduleId+date) as the original
+   * schedule, so the app's existing cancelAlarm() — called the moment the dose
+   * is marked Taken/Skipped — cancels the pending re-reminder too. Snoozing
+   * re-schedules the dose afresh (repeatCount back to 0), which replaces this.
+   *
+   * The new alarm is also persisted via AlarmPreferences so a reboot mid-loop
+   * re-arms it with the correct repeat count (BootReceiver), never duplicating.
+   */
+  private fun scheduleReRemind() {
+    if (cachedScheduleId.isEmpty()) return
+    if (cachedRepeatCount >= MAX_REMINDERS) {
+      Log.i(TAG, "re-remind cap reached ($MAX_REMINDERS) — leaving silent reminder only")
+      return
+    }
+
+    val nextCount = cachedRepeatCount + 1
+    val fireAt = System.currentTimeMillis() + REMIND_INTERVAL_MIN * 60_000L
+
+    val alarmManager = getSystemService(Context.ALARM_SERVICE) as? AlarmManager ?: return
+    val pendingIntent = AlarmIntentHelper.buildReceiverPendingIntent(
+      this,
+      cachedScheduleId,
+      cachedMedicationId,
+      cachedScheduledDate,
+      cachedScheduledTime,
+      cachedMedName,
+      cachedDose,
+      repeatCount = nextCount,
+    )
+    // setAlarmClock() bypasses Doze without any permission — same call the JS
+    // scheduleAlarm() and BootReceiver use, so behaviour is identical.
+    alarmManager.setAlarmClock(AlarmManager.AlarmClockInfo(fireAt, null), pendingIntent)
+
+    // Persist so BootReceiver re-arms this re-reminder (with its count) after a
+    // reboot, and so cancelAlarm() removes it from storage on Take/Skip.
+    AlarmPreferences.addScheduledAlarm(
+      this,
+      AlarmPreferences.StoredAlarm(
+        scheduleId = cachedScheduleId,
+        medicationId = cachedMedicationId,
+        scheduledDate = cachedScheduledDate,
+        scheduledTime = cachedScheduledTime,
+        medicationName = cachedMedName,
+        dose = cachedDose,
+        fireTimestamp = fireAt,
+        repeatCount = nextCount,
+      )
+    )
+    Log.i(TAG, "re-reminder $nextCount/$MAX_REMINDERS armed for $cachedScheduleId in ${REMIND_INTERVAL_MIN}m")
   }
 
   override fun onDestroy() {

--- a/modules/expo-alarm/android/src/main/java/expo/modules/alarm/AlarmIntentHelper.kt
+++ b/modules/expo-alarm/android/src/main/java/expo/modules/alarm/AlarmIntentHelper.kt
@@ -47,6 +47,8 @@ internal object AlarmIntentHelper {
     scheduledTime: String,
     medicationName: String,
     dose: String,
+    /** Auto-re-reminder index for this dose (0 = original schedule). */
+    repeatCount: Int = 0,
   ): PendingIntent {
     val requestCode = requestCodeFor(scheduleId, scheduledDate)
     val intent = Intent(context, AlarmReceiver::class.java).apply {
@@ -56,6 +58,7 @@ internal object AlarmIntentHelper {
       putExtra(AlarmAudioService.EXTRA_SCHEDULED_TIME,  scheduledTime)
       putExtra(AlarmAudioService.EXTRA_MEDICATION_NAME, medicationName)
       putExtra(AlarmAudioService.EXTRA_DOSE,            dose)
+      putExtra(AlarmAudioService.EXTRA_REPEAT_COUNT,    repeatCount)
     }
     return PendingIntent.getBroadcast(
       context,

--- a/modules/expo-alarm/android/src/main/java/expo/modules/alarm/AlarmPreferences.kt
+++ b/modules/expo-alarm/android/src/main/java/expo/modules/alarm/AlarmPreferences.kt
@@ -62,6 +62,8 @@ object AlarmPreferences {
     val medicationName: String,
     val dose: String,
     val fireTimestamp: Long,
+    /** Auto-re-reminder index (0 = original schedule); preserved across reboots. */
+    val repeatCount: Int = 0,
   )
 
   /** Records (or updates) an armed alarm. Keyed by (scheduleId, scheduledDate)
@@ -99,6 +101,7 @@ object AlarmPreferences {
           medicationName = o.optString("medicationName"),
           dose = o.optString("dose"),
           fireTimestamp = o.optLong("fireTimestamp"),
+          repeatCount = o.optInt("repeatCount", 0),
         )
       }
     } catch (e: Exception) {
@@ -118,6 +121,7 @@ object AlarmPreferences {
         put("medicationName", a.medicationName)
         put("dose", a.dose)
         put("fireTimestamp", a.fireTimestamp)
+        put("repeatCount", a.repeatCount)
       })
     }
     prefs(context).edit().putString(KEY_SCHEDULED_ALARMS, arr.toString()).apply()

--- a/modules/expo-alarm/android/src/main/java/expo/modules/alarm/BootReceiver.kt
+++ b/modules/expo-alarm/android/src/main/java/expo/modules/alarm/BootReceiver.kt
@@ -52,6 +52,7 @@ class BootReceiver : BroadcastReceiver() {
           alarm.scheduledTime,
           alarm.medicationName,
           alarm.dose,
+          repeatCount = alarm.repeatCount,
         )
         // setAlarmClock() needs no permission and bypasses Doze (same call
         // ExpoAlarmModule.scheduleAlarm uses).

--- a/modules/expo-alarm/app.plugin.js
+++ b/modules/expo-alarm/app.plugin.js
@@ -43,7 +43,9 @@ const withExpoAlarm = (config) => {
 
     ensurePermission(androidManifest, "android.permission.WAKE_LOCK");
     ensurePermission(androidManifest, "android.permission.FOREGROUND_SERVICE");
-    ensurePermission(androidManifest, "android.permission.FOREGROUND_SERVICE_ALARM");
+    // NOTE: no FOREGROUND_SERVICE_ALARM — that is not a real Android permission
+    // and there is no "alarm" foreground-service type. The alarm audio runs as
+    // a shortService FGS, which needs only FOREGROUND_SERVICE (above).
     ensurePermission(androidManifest, "android.permission.USE_FULL_SCREEN_INTENT");
 
     // Location permissions imply GPS/network hardware as required by default.


### PR DESCRIPTION
## Why

The alarm foreground service ran as **`FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK`** (in the local `expo-alarm` module) to play the reminder sound. That forces a **Google Play foreground-service declaration + demo video** and is a policy gray area for what is actually an alarm app — Play was requesting the declaration for vc21.

**Premise correction:** there is **no `alarm` FGS type** and **no `FOREGROUND_SERVICE_ALARM` permission** in Android (verified against `android-36`). The `FOREGROUND_SERVICE_ALARM` that was declared in `app.json` / `app.plugin.js` was a **phantom no-op**. So "switch to the ALARM type" was never possible.

## What changed

### 1. Compliance fix — `shortService` FGS
- Retype `AlarmAudioService` from `mediaPlayback` → **`shortService`**, the only non-system FGS type **exempt from the Play FGS declaration** (needs just `FOREGROUND_SERVICE`).
- Remove `FOREGROUND_SERVICE_MEDIA_PLAYBACK` and the phantom `FOREGROUND_SERVICE_ALARM`.
- Add `onTimeout()` (API 34 + API 35 overloads) to stop gracefully at the system's ~3-min `shortService` cap instead of crashing with `ForegroundServiceDidNotStopInTimeException`.
- Matches **MyTherapy**'s Android model (exact-alarm + full-screen-intent notifications, re-remind loop, **no** media-playback FGS).

### 2. Behavior fix — re-remind loop (patient safety)
`shortService` caps the ring at ~3 min, so an ignored dose would otherwise go silent. To keep parity with "remind until confirmed":
- When a ring ends **without the dose being logged** (timeout **or** swipe-away), re-arm the same alarm **`REMIND_INTERVAL_MIN` (5)** minutes later, up to **`MAX_REMINDERS` (6)** times (~30 min of nudging), then leave a persistent silent reminder.
- Reuses the **deterministic PendingIntent** (`requestCode = scheduleId+date`), so the app's existing `cancelAlarm()` — called the instant a dose is marked **Taken/Skipped** (`medications.markDose` → `cancelDoseNotifications`) — cancels the pending re-reminder too. **Snooze** re-schedules afresh (`repeatCount` back to 0).
- `repeatCount` travels in the intent and is **persisted**, so a reboot mid-loop resumes with the right count (`BootReceiver`).

### Version
`1.6.1 → 1.6.2` (versionCode `21 → 22`).

## ⚠️ Behavior tradeoff (by design)
The alarm now rings up to ~3 min per cycle (was: indefinitely), then re-nags every 5 min up to 6 times. The two knobs are single constants in `AlarmAudioService` (`REMIND_INTERVAL_MIN`, `MAX_REMINDERS`) — trivial to lift into Settings later. The **swipe-away** path also re-arms (a swipe isn't logging the dose) — flag if you'd rather swipe fully dismiss.

## Verification
- ✅ `shortService` type + both `onTimeout` override signatures exist in `android-36`.
- ✅ No source references `FOREGROUND_SERVICE_MEDIA_PLAYBACK` / phantom perm (only `android/build/**` stale cache — gitignored, regenerates clean).
- ✅ Re-remind cancels via the existing `cancelAlarm(scheduleId, date)` path (same requestCode) on Take/Skip from **any** surface (UI or notification).
- ⛔ **Not built here** — needs `expo prebuild -p android` + Gradle (regenerates `android/`).

## Required before merge/release
```
npx expo prebuild -p android --clean
grep -n "foregroundServiceType\|MEDIA_PLAYBACK" android/app/src/main/AndroidManifest.xml   # expect shortService, no MEDIA_PLAYBACK
npm run build:android
```
Then **on-device test**: alarm rings → ignore it → confirm it re-nags at ~5-min intervals; mark Taken → confirm re-reminders stop; reboot mid-loop → confirm it resumes. After this, the Play Console should stop requesting the foreground-service declaration.

## Known limitation (pre-existing, not introduced here)
Two doses firing in the same minute share one service instance, so only the last one re-reminds — a separate concurrent-dose fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
