### PR TITLE
feat(settings): configurable default snooze interval (F1)

### DIFF
--- a/__tests__/snoozeSettings.test.ts
+++ b/__tests__/snoozeSettings.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Unit tests for the user-configurable default snooze interval (F1).
+ * storage is backed by the __mocks__/react-native-mmkv in-memory store.
+ */
+import {
+  SNOOZE_OPTIONS,
+  DEFAULT_SNOOZE_MINUTES,
+  getDefaultSnoozeMinutes,
+  setDefaultSnoozeMinutes,
+} from "../src/services/snoozeSettings";
+import { storage } from "../src/storage";
+import { STORAGE_KEYS } from "../src/config";
+
+describe("snoozeSettings", () => {
+  beforeEach(() => {
+    storage.delete(STORAGE_KEYS.SNOOZE_MINUTES);
+  });
+
+  it("falls back to DEFAULT_SNOOZE_MINUTES when unset", () => {
+    expect(getDefaultSnoozeMinutes()).toBe(DEFAULT_SNOOZE_MINUTES);
+  });
+
+  it("persists and returns a valid option", () => {
+    setDefaultSnoozeMinutes(30);
+    expect(getDefaultSnoozeMinutes()).toBe(30);
+    expect(storage.getString(STORAGE_KEYS.SNOOZE_MINUTES)).toBe("30");
+  });
+
+  it("accepts every offered option", () => {
+    for (const min of SNOOZE_OPTIONS) {
+      setDefaultSnoozeMinutes(min);
+      expect(getDefaultSnoozeMinutes()).toBe(min);
+    }
+  });
+
+  it("throws on values outside SNOOZE_OPTIONS", () => {
+    expect(() => setDefaultSnoozeMinutes(7)).toThrow();
+    expect(() => setDefaultSnoozeMinutes(0)).toThrow();
+    expect(() => setDefaultSnoozeMinutes(-5)).toThrow();
+    // Nothing was persisted by the failed attempts
+    expect(getDefaultSnoozeMinutes()).toBe(DEFAULT_SNOOZE_MINUTES);
+  });
+
+  it("falls back when storage holds a corrupt value", () => {
+    storage.set(STORAGE_KEYS.SNOOZE_MINUTES, "garbage");
+    expect(getDefaultSnoozeMinutes()).toBe(DEFAULT_SNOOZE_MINUTES);
+    storage.set(STORAGE_KEYS.SNOOZE_MINUTES, "12"); // numeric but not an offered option
+    expect(getDefaultSnoozeMinutes()).toBe(DEFAULT_SNOOZE_MINUTES);
+  });
+});

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -15,6 +15,8 @@ import { checkFullScreenIntentPermission, requestFullScreenIntentPermission, get
 import type { AlarmSound } from "expo-alarm";
 import { useAppTheme } from "../../src/hooks/useAppTheme";
 import { AlarmSoundPicker } from "../../components/AlarmSoundPicker";
+import { SNOOZE_OPTIONS, getDefaultSnoozeMinutes, setDefaultSnoozeMinutes } from "../../src/services/snoozeSettings";
+import { refreshDoseReminderCategory } from "../../src/services/notifications";
 
 // ─── Sub-components ────────────────────────────────────────────────────────
 
@@ -127,6 +129,19 @@ export default function SettingsScreen() {
   // Alarm sound selection (Android only)
   const [alarmSoundExpanded, setAlarmSoundExpanded] = useState(false);
   const [currentSoundTitle, setCurrentSoundTitle] = useState<string>("");
+
+  // Default snooze interval (F1: configurable snooze)
+  const [snoozeMinutes, setSnoozeMinutesState] = useState(getDefaultSnoozeMinutes);
+
+  const handleSnoozeMinutes = (min: number) => {
+    if (min === snoozeMinutes) return;
+    Haptics.selectionAsync();
+    setSnoozeMinutesState(min);
+    setDefaultSnoozeMinutes(min);
+    // Fire-and-forget: refresh the notification quick-action label so the
+    // ⏰ button shows the new interval on future reminders.
+    refreshDoseReminderCategory().catch(() => {});
+  };
 
   useFocusEffect(
     useCallback(() => {
@@ -338,6 +353,41 @@ export default function SettingsScreen() {
             )}
           </>
         )}
+
+        {/* ─── Snooze default (F1: configurable snooze) ─── */}
+        <SectionHeader title={t("settings.sectionSnooze")} />
+        <View className="mx-5 rounded-2xl overflow-hidden bg-card px-4 py-3.5" style={{ shadowColor: "#000", shadowOpacity: 0.04, shadowRadius: 8, elevation: 2 }}>
+          <View className="flex-row items-center gap-3 mb-3">
+            <Ionicons name="alarm-outline" size={20} color="#f59e0b" />
+            <View className="flex-1">
+              <Text className="text-[15px] font-semibold text-text">{t("settings.snoozeDefaultTitle")}</Text>
+              <Text className="text-xs text-muted mt-0.5 leading-4">{t("settings.snoozeDefaultSubtitle")}</Text>
+            </View>
+          </View>
+          <View className="flex-row flex-wrap gap-2">
+            {SNOOZE_OPTIONS.map((min) => {
+              const selected = min === snoozeMinutes;
+              return (
+                <TouchableOpacity
+                  key={min}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected }}
+                  accessibilityLabel={t("settings.snoozeOptionA11y", { minutes: min })}
+                  onPress={() => handleSnoozeMinutes(min)}
+                  className={`rounded-xl px-3.5 py-2 border ${
+                    selected
+                      ? "bg-amber-500 border-amber-600 dark:bg-amber-600 dark:border-amber-500"
+                      : "bg-amber-50 border-amber-200 dark:bg-amber-950/30 dark:border-amber-800"
+                  }`}
+                >
+                  <Text className={`font-bold text-sm ${selected ? "text-white" : "text-amber-700 dark:text-amber-300"}`}>
+                    {min} min
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        </View>
 
         {/* ─── Your data ─── */}
         <SectionHeader title={t("settings.sectionData")} />

--- a/app/alarm.tsx
+++ b/app/alarm.tsx
@@ -5,7 +5,7 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useRef, useState } from "react";
 import { useAppStore } from "../src/store";
 import { getColorConfig, formatTimeForDisplay, getLocalizedDosage } from "../src/utils";
-import { SNOOZE_OPTIONS, DEFAULT_SNOOZE_MINUTES } from "../src/services/notifications";
+import { SNOOZE_OPTIONS, getDefaultSnoozeMinutes } from "../src/services/snoozeSettings";
 import { useTranslation } from "../src/i18n";
 import { stopAlarm, setAlarmWindowFlags, clearAlarmWindowFlags } from "expo-alarm";
 import { AppPressable } from "../components/AppPressable";
@@ -164,7 +164,11 @@ export default function AlarmScreen() {
     router.back();
   };
 
-  const handleSnooze = async (minutes: number = DEFAULT_SNOOZE_MINUTES) => {
+  // User-configured default (Settings) — highlights the matching chip below and
+  // is what the plain "Snooze" path uses.
+  const defaultSnoozeMinutes = getDefaultSnoozeMinutes();
+
+  const handleSnooze = async (minutes: number = defaultSnoozeMinutes) => {
     await stopAlarm();
     await snoozeDose(dose, minutes);
     router.back();
@@ -291,7 +295,7 @@ export default function AlarmScreen() {
             </Text>
             <View className="flex-row flex-wrap justify-center gap-2.5">
               {SNOOZE_OPTIONS.map((min) => {
-                const isDefault = min === DEFAULT_SNOOZE_MINUTES;
+                const isDefault = min === defaultSnoozeMinutes;
                 return (
                   <AppPressable
                     key={min}

--- a/components/DoseCard.tsx
+++ b/components/DoseCard.tsx
@@ -13,7 +13,7 @@ import * as Haptics from "expo-haptics";
 import { useState, useRef, useEffect } from "react";
 import { TodayDose, SkipReason } from "../src/types";
 import { CATEGORY_CONFIG, getCategoryLabel, getColorConfig, formatTimeForDisplay, getLocalizedDosage } from "../src/utils";
-import { SNOOZE_OPTIONS, DEFAULT_SNOOZE_MINUTES } from "../src/services/notifications";
+import { SNOOZE_OPTIONS, getDefaultSnoozeMinutes } from "../src/services/snoozeSettings";
 import { useTranslation } from "../src/i18n";
 import { useAppTheme } from "../src/hooks/useAppTheme";
 import { AppPressable } from "./AppPressable";
@@ -37,7 +37,10 @@ const SNOOZE_ITEM_H = 52;
 const SNOOZE_VISIBLE = 5;
 const SNOOZE_PICKER_H = SNOOZE_ITEM_H * SNOOZE_VISIBLE;
 const SNOOZE_PAD = SNOOZE_ITEM_H * Math.floor(SNOOZE_VISIBLE / 2);
-const SNOOZE_DEFAULT_IDX = (SNOOZE_OPTIONS as readonly number[]).indexOf(DEFAULT_SNOOZE_MINUTES);
+// Index of the user-configured default interval; read at call time so the
+// wheel pre-selects the latest Settings value (falls back to a valid index).
+const getSnoozeDefaultIdx = () =>
+  Math.max(0, (SNOOZE_OPTIONS as readonly number[]).indexOf(getDefaultSnoozeMinutes()));
 
 interface SnoozeWheelItemProps {
   minutes: number;
@@ -117,20 +120,22 @@ export function DoseCard({ dose, onTake, onSkip, onSnooze, onRevert, onReschedul
   ).current;
 
   // Snooze wheel picker
-  const snoozeScrollY = useSharedValue(SNOOZE_DEFAULT_IDX * SNOOZE_ITEM_H);
+  const snoozeScrollY = useSharedValue(getSnoozeDefaultIdx() * SNOOZE_ITEM_H);
   const snoozeScrollHandler = useAnimatedScrollHandler({
     onScroll: (e) => { snoozeScrollY.value = e.contentOffset.y; },
   });
   const snoozeListRef = useRef<any>(null);
-  const [selectedSnoozeIdx, setSelectedSnoozeIdx] = useState(SNOOZE_DEFAULT_IDX);
+  const [selectedSnoozeIdx, setSelectedSnoozeIdx] = useState(getSnoozeDefaultIdx);
 
   useEffect(() => {
     if (snoozePickerVisible) {
+      // Re-read on every open so a Settings change is reflected immediately.
+      const defaultIdx = getSnoozeDefaultIdx();
       setShowCustomSnooze(false);
-      setSelectedSnoozeIdx(SNOOZE_DEFAULT_IDX);
-      snoozeScrollY.value = SNOOZE_DEFAULT_IDX * SNOOZE_ITEM_H;
+      setSelectedSnoozeIdx(defaultIdx);
+      snoozeScrollY.value = defaultIdx * SNOOZE_ITEM_H;
       const timer = setTimeout(() => {
-        snoozeListRef.current?.scrollTo?.({ y: SNOOZE_DEFAULT_IDX * SNOOZE_ITEM_H, animated: false });
+        snoozeListRef.current?.scrollTo?.({ y: defaultIdx * SNOOZE_ITEM_H, animated: false });
       }, 100);
       return () => clearTimeout(timer);
     }

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,11 @@ module.exports = {
     "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|nativewind|react-native-css-interop|date-fns)",
   ],
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  // Claude Code worktrees under .claude/ contain a full copy of the repo;
+  // without these ignores jest-haste-map sees duplicate modules (expo-alarm)
+  // and the worktree's __tests__ get picked up twice.
+  modulePathIgnorePatterns: ["<rootDir>/.claude/"],
+  testPathIgnorePatterns: ["/node_modules/", "<rootDir>/.claude/"],
   collectCoverageFrom: [
     "src/store/slices/medications.ts",
     "src/services/backgroundTask.ts",

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,7 @@ export const STORAGE_KEYS = {
   EXACT_ALARM_PROMPTED:     "@pilloclock/exact_alarm_prompted",
   FULLSCREEN_INTENT_PROMPTED: "@pilloclock/fullscreen_intent_prompted",
   ALARM_SOUND_URI:            "@pilloclock/alarm_sound_uri",
+  SNOOZE_MINUTES:             "@pilloclock/snooze_minutes",
   RECENT_COLORS:            "custom_colors_recent",
   // Legacy keys kept for migration only (notifications.ts)
   NOTIF_MAP:                "@pilloclock/notif_map",

--- a/src/hooks/useNotificationResponse.ts
+++ b/src/hooks/useNotificationResponse.ts
@@ -7,10 +7,10 @@ import {
   ACTION_TAKEN,
   ACTION_SNOOZE,
   ACTION_SKIP,
-  SNOOZE_MINUTES,
   getNotifMapEntry,
   snoozeDose as snoozeDoseService,
 } from "../services/notifications";
+import { getDefaultSnoozeMinutes } from "../services/snoozeSettings";
 import { TodayDose } from "../types";
 
 /**
@@ -80,7 +80,7 @@ export function useNotificationResponseHandler() {
         } else if (actionId === ACTION_SNOOZE) {
           // Snooze needs the full medication/schedule objects.
           if (!med || !schedule) return;
-          const snoozeDate = addMinutes(new Date(), SNOOZE_MINUTES);
+          const snoozeDate = addMinutes(new Date(), getDefaultSnoozeMinutes());
           await snoozeDoseService(med, schedule, scheduledDate);
           // Update the in-memory snoozedTimes so the Home screen shows the new time.
           const snoozeHHmm = format(snoozeDate, "HH:mm");

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -527,6 +527,11 @@ const en: TranslationShape = {
     alarmSoundSubtitle: "Choose the sound for your medication alarms",
     alarmSoundDefault: "Pill O-Clock (default)",
     alarmSoundPlaying: "Playing…",
+    // Snooze default
+    sectionSnooze: "Snooze",
+    snoozeDefaultTitle: "Default interval",
+    snoozeDefaultSubtitle: "How long a dose is snoozed with the notification's ⏰ button",
+    snoozeOptionA11y: "Default snooze {{minutes}} minutes",
     // Appearance
     sectionAppearance: "Appearance",
     themeSystem: "Automatic (system)",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -525,6 +525,11 @@ const es = {
     alarmSoundSubtitle: "Elegí el sonido para tus alarmas de medicamentos",
     alarmSoundDefault: "Pill O-Clock (predeterminado)",
     alarmSoundPlaying: "Reproduciendo…",
+    // Snooze default
+    sectionSnooze: "Posponer",
+    snoozeDefaultTitle: "Intervalo por defecto",
+    snoozeDefaultSubtitle: "Cuánto se pospone una dosis con el botón ⏰ de la notificación",
+    snoozeOptionA11y: "Posponer por defecto {{minutes}} minutos",
     // Appearance
     sectionAppearance: "Apariencia",
     themeSystem: "Automático (sistema)",

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -8,6 +8,7 @@ import { Schedule, Medication, NotificationMap, Appointment } from "../types";
 import { parseTime, isScheduleActiveOnDate, getNextDates, toDateString, getLocalizedDosage } from "../utils";
 import i18n from "../i18n";
 import { STORAGE_KEYS } from "../config";
+import { getDefaultSnoozeMinutes as getSnoozeMin } from "./snoozeSettings";
 import { getMedications, getAllActiveSchedules, getDoseLogsByDateRange, getDb } from "../db/database";
 
 // ─── Constants ─────────────────────────────────────────────────────────────
@@ -15,9 +16,11 @@ import { getMedications, getAllActiveSchedules, getDoseLogsByDateRange, getDb } 
 export const NOTIFICATION_CHANNEL_ID = "pill-reminders-v2";
 // v2: correct sound reference (alarm.wav) + bypassDnd. Android channel settings are
 // immutable after creation, so a new ID forces a fresh channel on existing devices.
-export const SNOOZE_OPTIONS = [5, 10, 15, 20, 25, 30, 45, 60] as const;
-export const DEFAULT_SNOOZE_MINUTES = 15;
-export const SNOOZE_MINUTES = DEFAULT_SNOOZE_MINUTES;
+// Snooze interval setting lives in ./snoozeSettings (user-configurable, F1);
+// re-exported here for backwards compatibility with existing imports.
+export { SNOOZE_OPTIONS, DEFAULT_SNOOZE_MINUTES, getDefaultSnoozeMinutes, setDefaultSnoozeMinutes } from "./snoozeSettings";
+/** @deprecated Use getDefaultSnoozeMinutes() — the interval is user-configurable now. */
+export const SNOOZE_MINUTES = 15;
 export const REPEAT_INTERVAL_MINUTES = 5;
 /**
  * How many repeat reminders to schedule after the initial notification.
@@ -103,6 +106,35 @@ export async function openExactAlarmSettings(): Promise<void> {
   }
 }
 
+/**
+ * (Re)registers the DOSE_REMINDER action category (Take / Snooze / Skip).
+ *
+ * Called at startup and again whenever the default snooze interval changes in
+ * Settings, so the ⏰ action button label reflects the configured minutes.
+ * opensAppToForeground: true ensures the response listener always fires,
+ * even if the app was terminated when the user tapped the action.
+ */
+export async function refreshDoseReminderCategory(): Promise<void> {
+  if (Platform.OS === "web") return;
+  await Notifications.setNotificationCategoryAsync("DOSE_REMINDER", [
+    {
+      identifier: ACTION_TAKEN,
+      buttonTitle: i18n.t("notifications.actionTaken"),
+      options: { opensAppToForeground: true },
+    },
+    {
+      identifier: ACTION_SNOOZE,
+      buttonTitle: i18n.t("notifications.actionSnooze", { minutes: getSnoozeMin() }),
+      options: { opensAppToForeground: true },
+    },
+    {
+      identifier: ACTION_SKIP,
+      buttonTitle: i18n.t("notifications.actionSkip"),
+      options: { isDestructive: true, opensAppToForeground: true },
+    },
+  ]);
+}
+
 export async function setupNotifications(): Promise<NotificationSetupResult> {
   // Notifications are not supported on web
   if (Platform.OS === "web") {
@@ -122,25 +154,7 @@ export async function setupNotifications(): Promise<NotificationSetupResult> {
   });
 
   // Set action categories
-  // opensAppToForeground: true ensures the response listener always fires,
-  // even if the app was terminated when the user tapped the action.
-  await Notifications.setNotificationCategoryAsync("DOSE_REMINDER", [
-    {
-      identifier: ACTION_TAKEN,
-      buttonTitle: i18n.t("notifications.actionTaken"),
-      options: { opensAppToForeground: true },
-    },
-    {
-      identifier: ACTION_SNOOZE,
-      buttonTitle: i18n.t("notifications.actionSnooze", { minutes: SNOOZE_MINUTES }),
-      options: { opensAppToForeground: true },
-    },
-    {
-      identifier: ACTION_SKIP,
-      buttonTitle: i18n.t("notifications.actionSkip"),
-      options: { isDestructive: true, opensAppToForeground: true },
-    },
-  ]);
+  await refreshDoseReminderCategory();
 
   // Create Android channel
   if (Platform.OS === "android") {
@@ -421,14 +435,15 @@ export async function snoozeDose(
   medication: Medication,
   schedule: Schedule,
   scheduledDate: string,
-  /** When provided the notification fires at this exact time instead of now+15. */
+  /** When provided the notification fires at this exact time instead of now + the configured default. */
   fireDate?: Date
 ): Promise<void> {
   // Cancel existing alarm / notification chain for this dose.
   await removeNotifMapEntriesByDose(schedule.id, scheduledDate);
 
-  // Use explicit fire date when supplied (future-dose snooze), otherwise now+15
-  const snoozeDate = fireDate ?? addMinutes(new Date(), SNOOZE_MINUTES);
+  // Use explicit fire date when supplied (future-dose snooze), otherwise
+  // now + the user-configured default interval.
+  const snoozeDate = fireDate ?? addMinutes(new Date(), getSnoozeMin());
 
   // ── Android: re-schedule as an AlarmManager alarm ──────────────────────
   if (Platform.OS === "android") {

--- a/src/services/snoozeSettings.ts
+++ b/src/services/snoozeSettings.ts
@@ -1,0 +1,46 @@
+/**
+ * User-configurable default snooze interval (audit/backlog F1).
+ *
+ * Kept in its own module (instead of notifications.ts) so consumers that only
+ * need the setting — store slices, DoseCard, the alarm screen — don't pull in
+ * the whole notifications service (heavy expo imports, widely jest.mock()ed).
+ *
+ * The value is what the ⏰ Snooze quick-action on the notification uses, and
+ * what the per-dose pickers pre-select. Reads are synchronous (MMKV).
+ */
+import { storage } from "../storage";
+import { STORAGE_KEYS } from "../config";
+
+/** Options offered by every snooze picker, in minutes. */
+export const SNOOZE_OPTIONS = [5, 10, 15, 20, 25, 30, 45, 60] as const;
+
+/** Fallback when the user never changed the setting. */
+export const DEFAULT_SNOOZE_MINUTES = 15;
+
+/**
+ * Current default snooze interval in minutes.
+ * Falls back to DEFAULT_SNOOZE_MINUTES when unset or invalid.
+ */
+export function getDefaultSnoozeMinutes(): number {
+  const raw = storage.getString(STORAGE_KEYS.SNOOZE_MINUTES);
+  if (!raw) return DEFAULT_SNOOZE_MINUTES;
+  const parsed = Number(raw);
+  return (SNOOZE_OPTIONS as readonly number[]).includes(parsed)
+    ? parsed
+    : DEFAULT_SNOOZE_MINUTES;
+}
+
+/**
+ * Persists a new default snooze interval.
+ * Throws on values outside SNOOZE_OPTIONS (programmer error — the UI only
+ * offers valid options).
+ *
+ * Note: after changing it, call refreshDoseReminderCategory() (notifications
+ * service) so the notification action button label shows the new interval.
+ */
+export function setDefaultSnoozeMinutes(minutes: number): void {
+  if (!(SNOOZE_OPTIONS as readonly number[]).includes(minutes)) {
+    throw new Error(`Invalid snooze interval: ${minutes}`);
+  }
+  storage.set(STORAGE_KEYS.SNOOZE_MINUTES, String(minutes));
+}

--- a/src/store/slices/medications.ts
+++ b/src/store/slices/medications.ts
@@ -34,10 +34,10 @@ import {
   cancelDoseNotifications,
   cancelScheduleNotifications,
   snoozeDose,
-  DEFAULT_SNOOZE_MINUTES,
   scheduleStockAlert,
   DAYS_AHEAD,
 } from "../../services/notifications";
+import { getDefaultSnoozeMinutes } from "../../services/snoozeSettings";
 
 export const createMedicationsSlice: StateCreator<AppState, [], [], MedicationsSlice> = (set, get) => ({
   medications: [],
@@ -246,7 +246,7 @@ export const createMedicationsSlice: StateCreator<AppState, [], [], MedicationsS
 
   // ── Snooze ─────────────────────────────────────────────────────────────
 
-  async snoozeDose(dose, minutes = DEFAULT_SNOOZE_MINUTES) {
+  async snoozeDose(dose, minutes = getDefaultSnoozeMinutes()) {
     const now = new Date();
     const [sh, sm] = dose.schedule.time.split(":").map(Number);
     const originalDateTime = new Date(


### PR DESCRIPTION
First Phase-1 feature from the strategic product backlog: the default snooze interval is now user-configurable.

- New `src/services/snoozeSettings.ts` (MMKV-persisted, validated, 15-min fallback), kept separate from the heavy notifications service.
- Settings: new "Snooze" section with option chips (5–60 min), ES/EN + a11y.
- Notification ⏰ quick-action, iOS action handler, store default, alarm screen and DoseCard wheel all honor the setting; the DOSE_REMINDER category re-registers on change so the button label updates.
- Test-infra fix: jest now ignores `.claude/` worktrees (duplicate haste modules previously broke the entire suite whenever a worktree existed).

Validation: tsc (no new errors vs main), ESLint (0 errors, warnings pre-existing), Jest **181/181** incl. new 5-case suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
