### PR TITLE
feat(stock): prescription-renewal reminders + days-of-supply (F1)

### DIFF
--- a/__tests__/backgroundTask.test.ts
+++ b/__tests__/backgroundTask.test.ts
@@ -36,6 +36,8 @@ jest.mock("../src/services/notifications", () => ({
   scheduleDoseChain: jest.fn().mockResolvedValue(undefined),
   snoozeDose: jest.fn().mockResolvedValue(undefined),
   scheduleStockAlert: jest.fn().mockResolvedValue(undefined),
+  scheduleRenewalReminders: jest.fn().mockResolvedValue(undefined),
+  cancelRenewalReminders: jest.fn().mockResolvedValue(undefined),
   SNOOZE_MINUTES: 15,
   DEFAULT_SNOOZE_MINUTES: 15,
   SNOOZE_OPTIONS: [5, 10, 15, 20, 25, 30, 45, 60],

--- a/__tests__/store/markDose.test.ts
+++ b/__tests__/store/markDose.test.ts
@@ -40,6 +40,8 @@ jest.mock("../../src/services/notifications", () => ({
   scheduleDoseChain: jest.fn().mockResolvedValue(undefined),
   snoozeDose: jest.fn().mockResolvedValue(undefined),
   scheduleStockAlert: jest.fn().mockResolvedValue(undefined),
+  scheduleRenewalReminders: jest.fn().mockResolvedValue(undefined),
+  cancelRenewalReminders: jest.fn().mockResolvedValue(undefined),
   rescheduleAllNotifications: jest.fn().mockResolvedValue(undefined),
   SNOOZE_MINUTES: 15,
   DEFAULT_SNOOZE_MINUTES: 15,

--- a/__tests__/store/medicationsSlice.test.ts
+++ b/__tests__/store/medicationsSlice.test.ts
@@ -35,6 +35,7 @@ jest.mock("../../src/db/database", () => ({
   deleteMedication: jest.fn().mockResolvedValue(undefined),
   deleteSchedule: jest.fn().mockResolvedValue(undefined),
   updateDoseLogNotes: jest.fn().mockResolvedValue(undefined),
+  setMedicationRenewalNotifIds: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock("../../src/services/notifications", () => ({
@@ -43,6 +44,8 @@ jest.mock("../../src/services/notifications", () => ({
   scheduleDoseChain: jest.fn().mockResolvedValue(undefined),
   snoozeDose: jest.fn().mockResolvedValue(undefined),
   scheduleStockAlert: jest.fn().mockResolvedValue(undefined),
+  scheduleRenewalReminders: jest.fn().mockResolvedValue(undefined),
+  cancelRenewalReminders: jest.fn().mockResolvedValue(undefined),
   rescheduleAllNotifications: jest.fn().mockResolvedValue(undefined),
   SNOOZE_MINUTES: 15,
   DEFAULT_SNOOZE_MINUTES: 15,

--- a/__tests__/supply.test.ts
+++ b/__tests__/supply.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for estimateDaysOfSupply (F1: refill/renewal).
+ */
+import { estimateDaysOfSupply } from "../src/utils";
+import { Medication, Schedule } from "../src/types";
+
+const med = (over: Partial<Medication> = {}): Medication => ({
+  id: "m1",
+  name: "Test",
+  dosageAmount: 1,
+  dosageUnit: "comprimidos",
+  dosage: "1 comprimidos",
+  category: "otro",
+  color: "blue",
+  isActive: true,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  stockQuantity: 14,
+  ...over,
+});
+
+const sched = (over: Partial<Schedule> = {}): Schedule => ({
+  id: "s1",
+  medicationId: "m1",
+  time: "08:00",
+  days: [],
+  isActive: true,
+  ...over,
+});
+
+describe("estimateDaysOfSupply", () => {
+  it("daily single dose: qty 14 → 14 days", () => {
+    expect(estimateDaysOfSupply(med(), [sched()])).toBe(14);
+  });
+
+  it("two doses per day: qty 14 → 7 days", () => {
+    expect(
+      estimateDaysOfSupply(med(), [sched(), sched({ id: "s2", time: "20:00" })])
+    ).toBe(7);
+  });
+
+  it("three days a week: qty 6 → 14 days", () => {
+    expect(
+      estimateDaysOfSupply(med({ stockQuantity: 6 }), [sched({ days: [1, 3, 5] })])
+    ).toBe(14);
+  });
+
+  it("returns null without stock tracking", () => {
+    expect(estimateDaysOfSupply(med({ stockQuantity: undefined }), [sched()])).toBeNull();
+  });
+
+  it("returns null for PRN meds", () => {
+    expect(estimateDaysOfSupply(med({ isPRN: true }), [sched()])).toBeNull();
+  });
+
+  it("returns null with no active schedules", () => {
+    expect(estimateDaysOfSupply(med(), [sched({ isActive: false })])).toBeNull();
+    expect(estimateDaysOfSupply(med(), [])).toBeNull();
+  });
+
+  it("ignores schedules of other medications", () => {
+    expect(
+      estimateDaysOfSupply(med(), [sched({ medicationId: "other" })])
+    ).toBeNull();
+  });
+});

--- a/app/medication/[id].tsx
+++ b/app/medication/[id].tsx
@@ -98,6 +98,7 @@ export default function EditMedicationScreen() {
     stockAlertThreshold: medication.stockAlertThreshold,
     isPRN: medication.isPRN,
     photoUri: medication.photoUri,
+    renewalDate: medication.renewalDate,
     schedules: schedules.map((s) => ({
       id: s.id,
       time: s.time,
@@ -124,6 +125,7 @@ export default function EditMedicationScreen() {
           stockAlertThreshold: values.stockAlertThreshold,
           isPRN: values.isPRN,
           photoUri: values.photoUri,
+          renewalDate: values.renewalDate,
         },
         // Pass each schedule's id through so unchanged schedules keep their
         // identity (and their dose_logs) instead of being deleted + recreated

--- a/app/medication/new.tsx
+++ b/app/medication/new.tsx
@@ -30,6 +30,7 @@ export default function NewMedicationScreen() {
           stockAlertThreshold: values.stockAlertThreshold,
           isPRN: values.isPRN,
           photoUri: values.photoUri,
+          renewalDate: values.renewalDate,
         },
         values.schedules.map((s) => ({ time: s.time, days: s.days }))
       );

--- a/components/AppLockGate.tsx
+++ b/components/AppLockGate.tsx
@@ -158,8 +158,10 @@ export function AppLockGate({ children }: { children: React.ReactNode }) {
       {children}
       {overlayVisible && (
         <View
-          className="absolute inset-0 items-center justify-center px-8"
-          style={{ backgroundColor: theme.background, zIndex: 999, elevation: 999 }}
+          className="absolute inset-0 items-center justify-center px-8 bg-background"
+          // Solid fallback color in case NativeWind's bg-background var fails:
+          // the overlay must NEVER be transparent (it hides health data).
+          style={{ backgroundColor: theme.isDark ? "#0b1220" : "#f1f5f9", zIndex: 999, elevation: 999 }}
           accessibilityViewIsModal
         >
           <Text style={{ fontSize: 44 }}>💊</Text>

--- a/components/MedicationCard.tsx
+++ b/components/MedicationCard.tsx
@@ -2,7 +2,7 @@
 import { Ionicons } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
 import { Medication, Schedule, DoseLog } from "../src/types";
-import { CATEGORY_CONFIG, getCategoryLabel, getDayNamesShort, getColorConfig, isScheduleActiveOnDate, toDateString, formatTimeForDisplay, getLocalizedDosage } from "../src/utils";
+import { CATEGORY_CONFIG, getCategoryLabel, getDayNamesShort, getColorConfig, isScheduleActiveOnDate, toDateString, formatTimeForDisplay, getLocalizedDosage, estimateDaysOfSupply } from "../src/utils";
 import { format } from "date-fns";
 import { useTranslation, getDateLocale } from "../src/i18n";
 import { useAppTheme } from "../src/hooks/useAppTheme";
@@ -188,6 +188,10 @@ export function MedicationCard({
               className="text-xs font-semibold"
             >
               {t('stock.badge', { count: qty })}
+              {(() => {
+                const days = estimateDaysOfSupply(medication, schedules);
+                return days != null ? ` · ${t('stock.daysLeft', { count: days })}` : "";
+              })()}
               {isLow ? ` · ${t('stock.low')}` : ""}
             </Text>
           </View>

--- a/components/MedicationForm.tsx
+++ b/components/MedicationForm.tsx
@@ -254,6 +254,8 @@ export interface MedicationFormValues {
   stockAlertThreshold?: number;
   isPRN?: boolean;
   photoUri?: string;
+  /** ISO date (YYYY-MM-DD) — optional prescription-renewal date. */
+  renewalDate?: string;
 }
 
 interface MedicationFormProps {
@@ -332,6 +334,7 @@ export function MedicationForm({
       stockQtyStr: initialValues?.stockQuantity != null ? String(initialValues.stockQuantity) : "",
       stockThreshStr: initialValues?.stockAlertThreshold != null ? String(initialValues.stockAlertThreshold) : "",
       photoUri: initialValues?.photoUri,
+      renewalDate: initialValues?.renewalDate,
     },
   });
 
@@ -408,6 +411,7 @@ export function MedicationForm({
       stockAlertThreshold: data.stockThreshStr?.trim() ? Math.max(0, parseInt(data.stockThreshStr, 10)) : undefined,
       isPRN: data.repeatMode === "prn",
       photoUri: data.photoUri,
+      renewalDate: data.renewalDate,
     });
   };
 
@@ -927,6 +931,14 @@ export function MedicationForm({
                 </View>
               </View>
             )}
+            {/* Prescription renewal (F1) */}
+            <DateRow
+              label={t('form.fieldRenewal')}
+              value={watch("renewalDate")}
+              onChange={(v) => setValue("renewalDate", v)}
+              minimumDate={new Date()}
+            />
+            <Text className="text-xs text-muted -mt-2">{t('form.fieldRenewalHint')}</Text>
           </View>
         </View>
       </ScrollView>

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -50,6 +50,8 @@ function toMedication(row: typeof schema.medications.$inferSelect): Medication {
     stockAlertThreshold: row.stockAlertThreshold ?? undefined,
     photoUri: row.photoUri ?? undefined,
     isPRN: row.isPRN,
+    renewalDate: row.renewalDate ?? undefined,
+    renewalNotifIds: row.renewalNotifIds ?? undefined,
   };
 }
 
@@ -166,7 +168,9 @@ export async function initDatabase(): Promise<void> {
       stock_quantity INTEGER,
       stock_alert_threshold INTEGER,
       photo_uri     TEXT,
-      is_prn        INTEGER NOT NULL DEFAULT 0
+      is_prn        INTEGER NOT NULL DEFAULT 0,
+      renewal_date  TEXT,
+      renewal_notif_ids TEXT
     );
 
     CREATE TABLE IF NOT EXISTS schedules (
@@ -338,6 +342,17 @@ export async function initDatabase(): Promise<void> {
     `);
     expoDb.execSync("PRAGMA user_version = 10");
   }
+
+  if (user_version < 11) {
+    // F1: prescription-renewal reminders.
+    for (const s of [
+      "ALTER TABLE medications ADD COLUMN renewal_date TEXT",
+      "ALTER TABLE medications ADD COLUMN renewal_notif_ids TEXT",
+    ]) {
+      try { expoDb.execSync(s); } catch { /* exists */ }
+    }
+    expoDb.execSync("PRAGMA user_version = 11");
+  }
 }
 
 // ─── Medications ───────────────────────────────────────────────────────────
@@ -370,6 +385,8 @@ export async function insertMedication(med: Medication): Promise<void> {
     stockAlertThreshold: med.stockAlertThreshold ?? null,
     photoUri: med.photoUri ?? null,
     isPRN: med.isPRN ?? false,
+    renewalDate: med.renewalDate ?? null,
+    renewalNotifIds: med.renewalNotifIds ?? null,
   }).run();
 }
 
@@ -389,7 +406,20 @@ export async function updateMedication(med: Medication): Promise<void> {
     stockAlertThreshold: med.stockAlertThreshold ?? null,
     photoUri: med.photoUri ?? null,
     isPRN: med.isPRN ?? false,
+    renewalDate: med.renewalDate ?? null,
+    renewalNotifIds: med.renewalNotifIds ?? null,
   }).where(eq(schema.medications.id, med.id)).run();
+}
+
+/** Persists only the renewal-reminder notification ids for a medication. */
+export async function setMedicationRenewalNotifIds(
+  id: string,
+  notifIds: string | null
+): Promise<void> {
+  db.update(schema.medications)
+    .set({ renewalNotifIds: notifIds })
+    .where(eq(schema.medications.id, id))
+    .run();
 }
 
 export async function deleteMedication(id: string): Promise<void> {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -19,6 +19,8 @@ export const medications = sqliteTable("medications", {
   stockAlertThreshold: integer("stock_alert_threshold"),
   photoUri: text("photo_uri"),
   isPRN: integer("is_prn", { mode: "boolean" }).notNull().default(false),
+  renewalDate: text("renewal_date"),
+  renewalNotifIds: text("renewal_notif_ids"),
 });
 
 // ─── Schedules ─────────────────────────────────────────────────────────────

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -192,6 +192,8 @@ const en: TranslationShape = {
     fieldStockThreshold: "Alert when below",
     fieldStockThresholdPlaceholder: "e.g. 5",
     fieldStockUnit: "units",
+    fieldRenewal: "Prescription renewal (optional)",
+    fieldRenewalHint: "We'll remind you 7 days before and on the day itself.",
     sectionPhoto: "Photo (optional)",
     addPhoto: "Add photo",
     changePhoto: "Change photo",
@@ -306,6 +308,11 @@ const en: TranslationShape = {
     badge_other: "{{count}} left",
     low: "Low stock",
     channelName: "Stock alerts",
+    daysLeft: "≈{{count}} days",
+    renewalSoonTitle: "{{name}} prescription expiring",
+    renewalSoonBody: "The renewal is due in 7 days. Book the appointment or request a new prescription.",
+    renewalTodayTitle: "Renew prescription: {{name}}",
+    renewalTodayBody: "The prescription renewal is due today.",
   },
 
   // ─── Appointments ─────────────────────────────────────────────────────────

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -190,6 +190,8 @@ const es = {
     fieldStockThreshold: "Alertar cuando queden menos de",
     fieldStockThresholdPlaceholder: "ej: 5",
     fieldStockUnit: "unidades",
+    fieldRenewal: "Renovación de receta (opcional)",
+    fieldRenewalHint: "Te avisamos 7 días antes y el mismo día.",
     sectionPhoto: "Foto (opcional)",
     addPhoto: "Agregar foto",
     changePhoto: "Cambiar foto",
@@ -304,6 +306,11 @@ const es = {
     badge_other: "Quedan {{count}}",
     low: "Stock bajo",
     channelName: "Alertas de stock",
+    daysLeft: "≈{{count}} días",
+    renewalSoonTitle: "Receta de {{name}} por vencer",
+    renewalSoonBody: "La renovación vence en 7 días. Pedí el turno o la receta nueva.",
+    renewalTodayTitle: "Renovar receta: {{name}}",
+    renewalTodayBody: "Hoy vence la renovación de la receta.",
   },
 
   // ─── Citas ───────────────────────────────────────────────────────────────

--- a/src/schemas/medication.ts
+++ b/src/schemas/medication.ts
@@ -22,6 +22,7 @@ export const medicationFormSchema = z
     stockQtyStr: z.string().optional().default(""),
     stockThreshStr: z.string().optional().default(""),
     photoUri: z.string().optional(),
+    renewalDate: z.string().optional(),
   })
   .superRefine((data, ctx) => {
     // Validate dosage is a positive number

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -602,6 +602,67 @@ export async function scheduleStockAlert(medication: Medication): Promise<void> 
   });
 }
 
+// ─── Prescription-renewal reminders (F1) ───────────────────────────────────
+
+/** Cancels any scheduled renewal reminders recorded on the medication. */
+export async function cancelRenewalReminders(med: Medication): Promise<void> {
+  if (Platform.OS === "web" || !med.renewalNotifIds) return;
+  await Promise.all(
+    med.renewalNotifIds
+      .split("|")
+      .filter(Boolean)
+      .map((id) => Notifications.cancelScheduledNotificationAsync(id).catch(() => {}))
+  );
+}
+
+/**
+ * Schedules prescription-renewal reminders for the medication:
+ *  - a heads-up 7 days before `renewalDate` at 10:00 (when still in the future)
+ *  - a reminder on the renewal day itself at 10:00
+ * Returns a pipe-separated id string to persist (or undefined when nothing
+ * was scheduled). Always cancel previous ids (cancelRenewalReminders) first.
+ */
+export async function scheduleRenewalReminders(
+  med: Medication
+): Promise<string | undefined> {
+  if (Platform.OS === "web" || !med.renewalDate) return undefined;
+
+  const [y, m, d] = med.renewalDate.split("-").map(Number);
+  if (!y || !m || !d) return undefined;
+  const now = new Date();
+  const ids: string[] = [];
+
+  const schedule = async (fireDate: Date, title: string, body: string) => {
+    if (fireDate <= now) return;
+    const id = await Notifications.scheduleNotificationAsync({
+      content: {
+        title,
+        body,
+        data: { type: "renewal", medicationId: med.id },
+        ...(Platform.OS === "android" ? { channelId: STOCK_ALERT_CHANNEL_ID } : {}),
+      },
+      trigger: { type: Notifications.SchedulableTriggerInputTypes.DATE, date: fireDate },
+    });
+    ids.push(id);
+  };
+
+  const onDate = new Date(y, m - 1, d, 10, 0, 0, 0);
+  const headsUp = new Date(onDate.getTime() - 7 * 24 * 60 * 60_000);
+
+  await schedule(
+    headsUp,
+    i18n.t("stock.renewalSoonTitle", { name: med.name }),
+    i18n.t("stock.renewalSoonBody")
+  );
+  await schedule(
+    onDate,
+    i18n.t("stock.renewalTodayTitle", { name: med.name }),
+    i18n.t("stock.renewalTodayBody")
+  );
+
+  return ids.length ? ids.join("|") : undefined;
+}
+
 // ─── Appointment notifications ─────────────────────────────────────────────
 
 export const APPOINTMENTS_CHANNEL_ID = "appointment-reminders";

--- a/src/store/slices/medications.ts
+++ b/src/store/slices/medications.ts
@@ -35,8 +35,11 @@ import {
   cancelScheduleNotifications,
   snoozeDose,
   scheduleStockAlert,
+  scheduleRenewalReminders,
+  cancelRenewalReminders,
   DAYS_AHEAD,
 } from "../../services/notifications";
+import { setMedicationRenewalNotifIds } from "../../db/database";
 import { getDefaultSnoozeMinutes } from "../../services/snoozeSettings";
 
 export const createMedicationsSlice: StateCreator<AppState, [], [], MedicationsSlice> = (set, get) => ({
@@ -69,6 +72,12 @@ export const createMedicationsSlice: StateCreator<AppState, [], [], MedicationsS
       })
     );
 
+    // Prescription-renewal reminders (F1).
+    if (med.renewalDate) {
+      const renewalIds = await scheduleRenewalReminders(med);
+      await setMedicationRenewalNotifIds(med.id, renewalIds ?? null);
+    }
+
     const allSchedules = await getAllActiveSchedules();
     const allMeds = await getMedications();
     set({ medications: allMeds, schedules: allSchedules });
@@ -79,6 +88,13 @@ export const createMedicationsSlice: StateCreator<AppState, [], [], MedicationsS
   // ── Update medication ──────────────────────────────────────────────────
 
   async updateMedication(med, scheduleInputs) {
+    // Re-plan renewal reminders: cancel whatever was scheduled for the
+    // previous renewalDate, then schedule for the (possibly new) one.
+    const prev = get().medications.find((m) => m.id === med.id);
+    if (prev) await cancelRenewalReminders(prev);
+    const renewalIds = await scheduleRenewalReminders(med);
+    med = { ...med, renewalNotifIds: renewalIds };
+
     await updateMedication(med);
 
     const existing = await getSchedulesByMedication(med.id);
@@ -126,6 +142,8 @@ export const createMedicationsSlice: StateCreator<AppState, [], [], MedicationsS
   async deleteMedication(id) {
     const schedules = await getSchedulesByMedication(id);
     await Promise.all(schedules.map((s) => cancelScheduleNotifications(s.id)));
+    const med = get().medications.find((m) => m.id === id);
+    if (med) await cancelRenewalReminders(med);
     await deleteMedication(id);
     const allSchedules = await getAllActiveSchedules();
     const allMeds = await getMedications();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -57,6 +57,10 @@ export interface Medication {
   photoUri?: string;
   /** If true, this medication has no fixed schedule — user logs it on demand. */
   isPRN?: boolean;
+  /** ISO date (YYYY-MM-DD) — when the prescription must be renewed (optional). */
+  renewalDate?: string;
+  /** Pipe-separated scheduled-notification ids for the renewal reminders. */
+  renewalNotifIds?: string;
 }
 
 // ─── Schedule ──────────────────────────────────────────────────────────────

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -192,3 +192,30 @@ export const CATEGORY_CONFIG: Record<
   vitamina:         { label: "Vitamina",          icon: "sunny-outline",        priority: 3, tint: "#eab308", labelLight: "#a16207", labelDark: "#facc15" },
   otro:             { label: "Otro",              icon: "medical-outline",      priority: 4, tint: "#64748b", labelLight: "#475569", labelDark: "#94a3b8" },
 };
+
+// ─── Days-of-supply estimate (F1: refill) ──────────────────────────────────
+
+/**
+ * Estimates how many days the current stock lasts, from the medication's
+ * active schedules (each scheduled dose consumes 1 stock unit, matching the
+ * markDose decrement). Returns null when it can't be estimated (no stock
+ * tracked, PRN meds, or no active schedules).
+ */
+export function estimateDaysOfSupply(
+  medication: Medication,
+  schedules: Schedule[]
+): number | null {
+  const qty = medication.stockQuantity;
+  if (qty == null || qty < 0 || medication.isPRN) return null;
+  const own = schedules.filter(
+    (s) => s.medicationId === medication.id && s.isActive
+  );
+  if (own.length === 0) return null;
+  // days = [] means "every day" (see schedule normalization in the form).
+  const dosesPerWeek = own.reduce(
+    (sum, s) => sum + (s.days.length === 0 ? 7 : s.days.length),
+    0
+  );
+  if (dosesPerWeek <= 0) return null;
+  return Math.floor((qty * 7) / dosesPerWeek);
+}


### PR DESCRIPTION
Phase-1 feature #3: explicit refill/renewal support layered on the existing stock tracking (closes the "MyTherapy advertises refill+renewal separately" gap, fully local).

- Optional **prescription-renewal date** per medication → local reminders 7 days before + on the day (stock-alerts channel), rescheduled on edit, cancelled on delete. DB migration v11.
- **Days-of-supply estimate** on the medication card (`stock ÷ weekly dose rate`, PRN-aware).
- Also ships a follow-up fix to #82: the app-lock overlay could render transparent (`theme.background` didn't exist); now solid in both themes.

Validation: Jest **194/194** (new 7-case supply suite), ESLint 0 errors, tsc no new errors (caught & fixed the overlay bug), no native changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
