### PR TITLE
feat(a11y): senior / low-vision mode (F1)

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -128,6 +128,8 @@ export default function SettingsScreen() {
   const loadAll = useAppStore((s) => s.loadAll);
   const themeMode = useAppStore((s) => s.themeMode);
   const setThemeMode = useAppStore((s) => s.setThemeMode);
+  const seniorMode = useAppStore((s) => s.seniorMode);
+  const setSeniorMode = useAppStore((s) => s.setSeniorMode);
 
   const [exporting, setExporting] = useState(false);
   const [importing, setImporting] = useState(false);
@@ -579,6 +581,21 @@ export default function SettingsScreen() {
               />
             </View>
           ))}
+          {/* Senior / low-vision mode (F1) */}
+          <Divider />
+          <View className="flex-row items-center px-4 py-3.5 gap-3">
+            <Ionicons name="text-outline" size={20} color={theme.primary} />
+            <View className="flex-1">
+              <Text className="text-[15px] font-semibold text-text">{t("settings.seniorMode")}</Text>
+              <Text className="text-xs text-muted mt-0.5 leading-4">{t("settings.seniorModeSubtitle")}</Text>
+            </View>
+            <Switch
+              value={seniorMode}
+              onValueChange={(on) => { Haptics.selectionAsync(); setSeniorMode(on); }}
+              trackColor={{ false: undefined, true: theme.primary }}
+              accessibilityLabel={t("settings.seniorMode")}
+            />
+          </View>
         </View>
 
         {/* ─── About ─── */}

--- a/components/DoseCard.tsx
+++ b/components/DoseCard.tsx
@@ -12,6 +12,7 @@ import { Ionicons } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
 import { useState, useRef, useEffect } from "react";
 import { TodayDose, SkipReason } from "../src/types";
+import { useAppStore } from "../src/store";
 import { CATEGORY_CONFIG, getCategoryLabel, getColorConfig, formatTimeForDisplay, getLocalizedDosage } from "../src/utils";
 import { SNOOZE_OPTIONS, getDefaultSnoozeMinutes } from "../src/services/snoozeSettings";
 import { useTranslation } from "../src/i18n";
@@ -84,6 +85,8 @@ const STATUS_ICONS = {
 export function DoseCard({ dose, onTake, onSkip, onSnooze, onRevert, onReschedule, onUpdateNote }: DoseCardProps) {
   const { t } = useTranslation();
   const theme = useAppTheme();
+  // Senior / low-vision mode (F1): larger type + taller touch targets.
+  const seniorMode = useAppStore((s) => s.seniorMode);
   const colors = getColorConfig(dose.medication.color);
   const statusTheme = theme.doseStatus[dose.status === "missed" ? "missed" : dose.status];
   const isPending = dose.status === "pending";
@@ -202,9 +205,9 @@ export function DoseCard({ dose, onTake, onSkip, onSnooze, onRevert, onReschedul
             </View>
           )}
           <View className="flex-1">
-            <Text className="text-base font-bold text-text" numberOfLines={1}>{dose.medication.name}</Text>
+            <Text className={`${seniorMode ? "text-xl" : "text-base"} font-bold text-text`} numberOfLines={1}>{dose.medication.name}</Text>
             <View className="flex-row items-center gap-1.5 mt-0.5 flex-shrink" style={{ overflow: 'hidden' }}>
-              <Text className="text-sm" style={{ color: theme.secondaryText }} numberOfLines={1}>{getLocalizedDosage(dose.medication, t)}</Text>
+              <Text className={seniorMode ? "text-base" : "text-sm"} style={{ color: theme.secondaryText }} numberOfLines={1}>{getLocalizedDosage(dose.medication, t)}</Text>
               <Text style={{ color: theme.secondaryText }}>·</Text>
               <Ionicons
                 name={CATEGORY_CONFIG[dose.medication.category].icon as any}
@@ -254,7 +257,7 @@ export function DoseCard({ dose, onTake, onSkip, onSnooze, onRevert, onReschedul
             style={{ color: isSnoozed
               ? (theme.isDark ? "#fbbf24" : "#92400e")
               : colors.text }}
-            className="text-sm font-bold"
+            className={`${seniorMode ? "text-lg" : "text-sm"} font-bold`}
           >
             {displayTimeFormatted}
           </Text>
@@ -321,10 +324,10 @@ export function DoseCard({ dose, onTake, onSkip, onSnooze, onRevert, onReschedul
               accessibilityRole="button"
               accessibilityLabel={t('doseCard.snooze')}
               onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); setSnoozePickerVisible(true); }}
-              className="flex-1 flex-row items-center justify-center gap-1.5 bg-amber-100 dark:bg-amber-900/30 border border-amber-300 dark:border-amber-700 rounded-xl px-3 py-3 min-h-[44px]"
+              className={`flex-1 flex-row items-center justify-center gap-1.5 bg-amber-100 dark:bg-amber-900/30 border border-amber-300 dark:border-amber-700 rounded-xl px-3 py-3 ${seniorMode ? "min-h-[56px]" : "min-h-[44px]"}`}
             >
               <Ionicons name="alarm-outline" size={16} color={theme.amber} />
-              <Text className="text-amber-700 dark:text-amber-300 text-sm font-semibold" numberOfLines={1}>{t('doseCard.snooze')}</Text>
+              <Text className={`text-amber-700 dark:text-amber-300 ${seniorMode ? "text-base" : "text-sm"} font-semibold`} numberOfLines={1}>{t('doseCard.snooze')}</Text>
             </AppPressable>
 
             {/* Skip */}
@@ -332,10 +335,10 @@ export function DoseCard({ dose, onTake, onSkip, onSnooze, onRevert, onReschedul
               accessibilityRole="button"
               accessibilityLabel={t('doseCard.skip')}
               onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); setSkipReasonVisible(true); }}
-              className="flex-1 flex-row items-center justify-center gap-1.5 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-xl px-3 py-3 min-h-[44px]"
+              className={`flex-1 flex-row items-center justify-center gap-1.5 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-xl px-3 py-3 ${seniorMode ? "min-h-[56px]" : "min-h-[44px]"}`}
             >
               <Ionicons name="close-outline" size={16} color={theme.danger} />
-              <Text className="text-red-700 dark:text-red-300 text-sm font-semibold" numberOfLines={1}>{t('doseCard.skip')}</Text>
+              <Text className={`text-red-700 dark:text-red-300 ${seniorMode ? "text-base" : "text-sm"} font-semibold`} numberOfLines={1}>{t('doseCard.skip')}</Text>
             </AppPressable>
 
             {/* Take */}
@@ -344,10 +347,10 @@ export function DoseCard({ dose, onTake, onSkip, onSnooze, onRevert, onReschedul
                 accessibilityRole="button"
                 accessibilityLabel={t('doseCard.take')}
                 onPress={handleTakePress}
-                className="flex-1 flex-row items-center justify-center gap-2 bg-green-700 rounded-xl px-3 py-3 min-h-[44px]"
+                className={`flex-1 flex-row items-center justify-center gap-2 bg-green-700 rounded-xl px-3 py-3 ${seniorMode ? "min-h-[56px]" : "min-h-[44px]"}`}
               >
-                <Ionicons name="checkmark" size={16} color="#fff" />
-                <Text className="text-white text-sm font-bold" numberOfLines={1}>{t('doseCard.take')}</Text>
+                <Ionicons name="checkmark" size={seniorMode ? 22 : 16} color="#fff" />
+                <Text className={`text-white ${seniorMode ? "text-lg" : "text-sm"} font-bold`} numberOfLines={1}>{t('doseCard.take')}</Text>
               </AppPressable>
               {/* Destello ring â€” expands and fades on tap */}
               <Animated.View

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,7 @@ export const STORAGE_KEYS = {
   SNOOZE_MINUTES:             "@pilloclock/snooze_minutes",
   APP_LOCK_ENABLED:           "@pilloclock/app_lock_enabled",
   APP_LOCK_BIOMETRIC:         "@pilloclock/app_lock_biometric",
+  SENIOR_MODE:                "@pilloclock/senior_mode",
   RECENT_COLORS:            "custom_colors_recent",
   // Legacy keys kept for migration only (notifications.ts)
   NOTIF_MAP:                "@pilloclock/notif_map",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -566,6 +566,8 @@ const en: TranslationShape = {
     rxtermsAttribution: "Medication name suggestions include RxTerms data, produced by the U.S. National Library of Medicine.",
     // Appearance
     sectionAppearance: "Appearance",
+    seniorMode: "Large text & buttons",
+    seniorModeSubtitle: "Enhanced-visibility mode for dose cards",
     themeSystem: "Automatic (system)",
     themeLight: "Light",
     themeDark: "Dark",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -564,6 +564,8 @@ const es = {
     rxtermsAttribution: "Las sugerencias de nombres de medicamentos incluyen datos de RxTerms, producido por la U.S. National Library of Medicine.",
     // Appearance
     sectionAppearance: "Apariencia",
+    seniorMode: "Texto y botones grandes",
+    seniorModeSubtitle: "Modo de visibilidad ampliada para las tarjetas de dosis",
     themeSystem: "Automático (sistema)",
     themeLight: "Claro",
     themeDark: "Oscuro",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -37,6 +37,13 @@ export const useAppStore = create<AppState>()((...a) => {
     todayLogs: [],
     isLoading: false,
     themeMode: "system" as ThemeMode,
+    // Senior mode reads synchronously so the first render is already scaled.
+    seniorMode: storage.getString(STORAGE_KEYS.SENIOR_MODE) === "1",
+
+    setSeniorMode(on: boolean) {
+      storage.set(STORAGE_KEYS.SENIOR_MODE, on ? "1" : "0");
+      set({ seniorMode: on });
+    },
 
     // ── Theme ──────────────────────────────────────────────────────────
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -77,6 +77,9 @@ export interface CoreSlice {
   todayLogs: DoseLog[];
   isLoading: boolean;
   themeMode: ThemeMode;
+  /** Senior / low-vision mode: larger type + touch targets on core surfaces (F1). */
+  seniorMode: boolean;
+  setSeniorMode: (on: boolean) => void;
   loadAll: () => Promise<void>;
   loadThemeMode: () => void;
   setThemeMode: (mode: ThemeMode) => void;


### PR DESCRIPTION
Phase-1 feature #6: opt-in senior / low-vision mode serving the core segment (elderly / polypharmacy).

- Settings → Appearance → "Large text & buttons" (persisted, reactive, sync-initialized).
- Dose cards scale: bigger name/dosage/time, 56 px touch targets on Take/Snooze/Skip.
- v1 covers the daily surface (Today cards); the alarm screen is already oversized by design. Iterates to more surfaces next.

Validation: Jest 200/200, ESLint 0 errors, tsc clean on changed files, no native changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
