### PR TITLE
feat(monetization): AdMob banner infrastructure, off by default (F1)

### DIFF
--- a/app.json
+++ b/app.json
@@ -75,6 +75,13 @@
         }
       ],
       "expo-secure-store",
+      [
+        "react-native-google-mobile-ads",
+        {
+          "androidAppId": "ca-app-pub-3940256099942544~3347511713",
+          "iosAppId": "ca-app-pub-3940256099942544~1458002511"
+        }
+      ],
       "./modules/expo-alarm/app.plugin.js",
       "./modules/expo-widget/app.plugin.js",
       [

--- a/app/(tabs)/health.tsx
+++ b/app/(tabs)/health.tsx
@@ -15,6 +15,7 @@ import { useTranslation, getDateLocale } from "../../src/i18n";
 import i18n from "../../src/i18n";
 import { SimpleLineChart } from "../../components/SimpleLineChart";
 import { CheckinModal } from "../../components/CheckinModal";
+import { AdBanner } from "../../components/AdBanner";
 import { EmptyState } from "../../components/EmptyState";
 import { useToast } from "../../src/context/ToastContext";
 import { today, formatTimeForDisplay } from "../../src/utils";
@@ -871,6 +872,8 @@ export default function HealthScreen() {
         onClose={() => setCheckinVisible(false)}
         existing={editCheckin}
       />
+      {/* Monetization slot (renders null while ads are disabled — see ads.ts) */}
+      <AdBanner />
     </SafeAreaView>
   );
 }

--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -1,6 +1,7 @@
 import { View, Text, ScrollView, TouchableOpacity, Animated, Alert } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
+import { AdBanner } from "../../components/AdBanner";
 import * as Haptics from "expo-haptics";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useFocusEffect } from "expo-router";
@@ -450,6 +451,8 @@ export default function HistoryScreen() {
         }
         ListFooterComponent={<View className="h-6" />}
       />
+      {/* Monetization slot (renders null while ads are disabled — see ads.ts) */}
+      <AdBanner />
     </SafeAreaView>
   );
 }

--- a/components/AdBanner.tsx
+++ b/components/AdBanner.tsx
@@ -1,0 +1,43 @@
+/**
+ * Anchored adaptive banner (F1 monetization). Renders NOTHING unless the
+ * master switch in src/services/ads.ts is on — see the policy there.
+ * Fails closed: any load error collapses the slot silently.
+ */
+import { useEffect, useState } from "react";
+import { View } from "react-native";
+import { adsEnabled, getBannerUnitId } from "../src/services/ads";
+
+export function AdBanner() {
+  const [ready, setReady] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    if (!adsEnabled()) return;
+    let cancelled = false;
+    // Deferred import: the ads SDK is only initialized when banners are on.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mobileAds = require("react-native-google-mobile-ads").default;
+    mobileAds()
+      .initialize()
+      .then(() => { if (!cancelled) setReady(true); })
+      .catch(() => { if (!cancelled) setFailed(true); });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (!adsEnabled() || failed || !ready) return null;
+
+  // Required lazily so the native module never loads while ads are disabled.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { BannerAd, BannerAdSize } = require("react-native-google-mobile-ads");
+
+  return (
+    <View className="items-center">
+      <BannerAd
+        unitId={getBannerUnitId()}
+        size={BannerAdSize.ANCHORED_ADAPTIVE_BANNER}
+        requestOptions={{ requestNonPersonalizedAdsOnly: true }}
+        onAdFailedToLoad={() => setFailed(true)}
+      />
+    </View>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "react-native": "0.81.5",
         "react-native-copilot": "^3.3.3",
         "react-native-gesture-handler": "~2.28.0",
+        "react-native-google-mobile-ads": "^15.7.0",
         "react-native-maps": "1.20.1",
         "react-native-mmkv": "^4.2.0",
         "react-native-reanimated": "~4.1.1",
@@ -4120,6 +4121,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@iabtcf/core": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@iabtcf/core/-/core-1.5.6.tgz",
+      "integrity": "sha512-u2q9thI9vLurYZdGtyJsDYOqoeLc4EgQsYGSc+UVibYII61B/ENJPZS6eFlML1F0hSoTR/goptpo5nGRDkKd2w==",
+      "license": "Apache-2.0"
     },
     "node_modules/@ide/backoff": {
       "version": "1.0.0",
@@ -8706,6 +8713,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -16532,6 +16548,24 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-google-mobile-ads": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/react-native-google-mobile-ads/-/react-native-google-mobile-ads-15.7.0.tgz",
+      "integrity": "sha512-VAskkfiK/ct9jer0XlASclgpiDLYnaLf4RPCcoenneZ3wVGfPwOtQ2T/HVZ6ZNc42BmRIRefqQSCWZPqIA2Drg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@iabtcf/core": "^1.5.3",
+        "use-deep-compare-effect": "^1.8.1"
+      },
+      "peerDependencies": {
+        "expo": ">=47.0.0"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-native-is-edge-to-edge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.3.1.tgz",
@@ -18821,6 +18855,23 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-deep-compare-effect": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz",
+      "integrity": "sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "dequal": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13"
       }
     },
     "node_modules/use-latest-callback": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-native": "0.81.5",
     "react-native-copilot": "^3.3.3",
     "react-native-gesture-handler": "~2.28.0",
+    "react-native-google-mobile-ads": "^15.7.0",
     "react-native-maps": "1.20.1",
     "react-native-mmkv": "^4.2.0",
     "react-native-reanimated": "~4.1.1",

--- a/src/services/ads.ts
+++ b/src/services/ads.ts
@@ -1,0 +1,37 @@
+/**
+ * Monetization: low-intrusion ad banners (F1 — stakeholder decision 2026-07).
+ *
+ * Policy (do not regress):
+ *  - Banners ONLY on secondary screens (History, Health). NEVER on the alarm
+ *    screen, the Today list, or the medication form. No interstitials, ever.
+ *  - Non-personalized ad requests only (privacy posture).
+ *
+ * MASTER SWITCH: ADS_ENABLED stays false until ALL of the following happen —
+ *  1. A real AdMob account exists and real app/unit IDs replace the Google
+ *     TEST IDs below (app IDs live in app.json + android AndroidManifest).
+ *  2. Play Console declarations are updated: "Anuncios" = Sí, "ID de
+ *     publicidad" = Sí, Data safety + advertising category.
+ *  3. Store listing copy no longer claims "no ads" (see store/play-store-*).
+ * Flipping this flag without (2)/(3) is a Play-policy violation.
+ *
+ * DEP PIN: react-native-google-mobile-ads is pinned to ^15.7.0
+ * (play-services-ads 24.5.0). Do NOT bump to 16.x until the project's Kotlin
+ * is ≥ 2.3 — 16.x pulls play-services-ads 25.x whose Kotlin metadata (2.3.0)
+ * fails to compile against RN 0.81 / Expo 54's Kotlin 2.1.
+ */
+import { Platform } from "react-native";
+
+export const ADS_ENABLED = false;
+
+/** Google's official test banner unit ids — safe to ship, never monetize. */
+const TEST_BANNER_ANDROID = "ca-app-pub-3940256099942544/9214589741";
+const TEST_BANNER_IOS = "ca-app-pub-3940256099942544/2435281174";
+
+export function adsEnabled(): boolean {
+  return ADS_ENABLED && Platform.OS !== "web";
+}
+
+export function getBannerUnitId(): string {
+  // Swap for real unit ids at launch (keep test ids for dev builds).
+  return Platform.OS === "ios" ? TEST_BANNER_IOS : TEST_BANNER_ANDROID;
+}


### PR DESCRIPTION
Phase-1 feature #7 (monetization decision, 2026-07): low-intrusion **banner infrastructure**, shipped **OFF by default**.

- `ADS_ENABLED = false` master switch with an explicit flip checklist: real AdMob IDs (needs the owner's AdMob account) + Play declarations update (Anuncios / AD_ID / Data safety) + store-copy fix. Flipping early would violate Play policy — the code enforces the sequencing.
- Policy encoded in code: banners **only** on History/Health; never on the alarm, Today, or med form; no interstitials; non-personalized requests.
- Google TEST app/unit IDs wired (app.json plugin + persistent manifest incl. the mandatory `APPLICATION_ID` meta-data that otherwise crashes the app at startup).
- Dep pinned `^15.7.0`: v16 pulls play-services-ads 25.x (Kotlin 2.3 metadata) which fails against RN 0.81's Kotlin 2.1 — documented in ads.ts. Native compile: **BUILD SUCCESSFUL**.

Validation: Jest 200/200, ESLint 0 errors, tsc clean on changed files, Gradle release-compile green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
