### PR TITLE
feat(safety): PRN dose limits — max/day + min spacing (F2)

### DIFF
--- a/__tests__/prnLimits.test.ts
+++ b/__tests__/prnLimits.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for PRN safety limits (F2).
+ */
+import { checkPrnLimits } from "../src/services/prnLimits";
+import { Medication, DoseLog } from "../src/types";
+
+const NOW = new Date(2026, 6, 22, 14, 0, 0); // 2026-07-22 14:00 local
+
+const med = (over: Partial<Medication> = {}): Medication => ({
+  id: "m1",
+  name: "Ibuprofeno",
+  dosageAmount: 1,
+  dosageUnit: "comprimidos",
+  dosage: "1 comprimidos",
+  category: "analgesico",
+  color: "blue",
+  isActive: true,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  isPRN: true,
+  prnMaxPerDay: 3,
+  prnMinIntervalMinutes: 360, // 6 h
+  ...over,
+});
+
+const takenLog = (hoursAgo: number, medicationId = "m1"): DoseLog => {
+  const at = new Date(NOW.getTime() - hoursAgo * 3_600_000);
+  const d = `${at.getFullYear()}-${String(at.getMonth() + 1).padStart(2, "0")}-${String(at.getDate()).padStart(2, "0")}`;
+  return {
+    id: `l${hoursAgo}`,
+    medicationId,
+    scheduleId: `prn-${medicationId}-x`,
+    scheduledDate: d,
+    scheduledTime: "00:00",
+    status: "taken",
+    takenAt: at.toISOString(),
+    createdAt: at.toISOString(),
+  };
+};
+
+describe("checkPrnLimits", () => {
+  it("passes with no logs", () => {
+    const c = checkPrnLimits(med(), [], NOW);
+    expect(c.blocked).toBe(false);
+    expect(c.takenToday).toBe(0);
+  });
+
+  it("flags overMax when today's taken count reaches the max", () => {
+    const logs = [takenLog(7), takenLog(9), takenLog(11)];
+    const c = checkPrnLimits(med(), logs, NOW);
+    expect(c.overMax).toBe(true);
+    expect(c.blocked).toBe(true);
+    expect(c.takenToday).toBe(3);
+  });
+
+  it("flags tooSoon inside the minimum interval with nextAllowedAt", () => {
+    const logs = [takenLog(2)]; // 2 h ago, min interval 6 h
+    const c = checkPrnLimits(med(), logs, NOW);
+    expect(c.tooSoon).toBe(true);
+    expect(c.blocked).toBe(true);
+    expect(c.nextAllowedAt?.getTime()).toBe(
+      NOW.getTime() - 2 * 3_600_000 + 6 * 3_600_000
+    );
+  });
+
+  it("passes when outside the interval and under the max", () => {
+    const logs = [takenLog(7)];
+    const c = checkPrnLimits(med(), logs, NOW);
+    expect(c.blocked).toBe(false);
+  });
+
+  it("considers yesterday's dose for the interval (cross-midnight)", () => {
+    const at2am = new Date(2026, 6, 22, 2, 0, 0);
+    const logs = [takenLog((NOW.getTime() - at2am.getTime()) / 3_600_000)];
+    // 12h interval, last dose 02:00, now 14:00 → exactly allowed
+    const c = checkPrnLimits(med({ prnMinIntervalMinutes: 720 }), logs, NOW);
+    expect(c.tooSoon).toBe(false);
+  });
+
+  it("ignores other medications and non-taken logs", () => {
+    const other = takenLog(1, "otherMed");
+    const skipped: DoseLog = { ...takenLog(1), status: "skipped", takenAt: undefined };
+    const c = checkPrnLimits(med(), [other, skipped], NOW);
+    expect(c.blocked).toBe(false);
+  });
+
+  it("no limits configured → never blocks", () => {
+    const c = checkPrnLimits(
+      med({ prnMaxPerDay: undefined, prnMinIntervalMinutes: undefined }),
+      [takenLog(0.1), takenLog(0.2), takenLog(0.3), takenLog(0.4)],
+      NOW
+    );
+    expect(c.blocked).toBe(false);
+  });
+});

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -4,6 +4,7 @@ import { useRouter, useFocusEffect } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
 import { format } from "date-fns";
+import { prnWarningMessage } from "../../src/services/prnLimits";
 import DateTimePicker, { DateTimePickerEvent } from "@react-native-community/datetimepicker";
 import { storage } from "../../src/storage";
 import { STORAGE_KEYS } from "../../src/config";
@@ -527,9 +528,25 @@ export default function HomeScreen() {
                               { text: t('common.cancel'), style: "cancel" },
                               {
                                 text: t('medicationCard.logPRNConfirmBtn'),
-                                onPress: () => {
+                                onPress: async () => {
+                                  const check = await logPRNDose(med);
+                                  if (check?.blocked) {
+                                    // PRN safety limit hit — warn, allow explicit override (F2).
+                                    Alert.alert(
+                                      t('prn.limitTitle'),
+                                      prnWarningMessage(t, med, check),
+                                      [
+                                        { text: t('common.cancel'), style: "cancel" },
+                                        {
+                                          text: t('prn.logAnyway'),
+                                          style: "destructive",
+                                          onPress: () => { logPRNDose(med, { force: true }); },
+                                        },
+                                      ]
+                                    );
+                                    return;
+                                  }
                                   Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-                                  logPRNDose(med);
                                 },
                               },
                             ]

--- a/app/(tabs)/medications.tsx
+++ b/app/(tabs)/medications.tsx
@@ -8,6 +8,7 @@ import { MedicationCard } from "../../components/MedicationCard";
 import { EmptyState } from "../../components/EmptyState";
 import { useState } from "react";
 import { useTranslation } from "../../src/i18n";
+import { prnWarningMessage } from "../../src/services/prnLimits";
 
 export default function MedicationsScreen() {
   const router = useRouter();
@@ -59,12 +60,27 @@ export default function MedicationsScreen() {
         { text: t('common.cancel'), style: "cancel" },
         {
           text: t('medicationCard.logPRNConfirmBtn'),
-          onPress: () => {
+          onPress: async () => {
             const med = medications.find((m) => m.id === id);
-            if (med) {
-              Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-              logPRNDose(med);
+            if (!med) return;
+            const check = await logPRNDose(med);
+            if (check?.blocked) {
+              // PRN safety limit hit — warn, allow explicit override (F2).
+              Alert.alert(
+                t('prn.limitTitle'),
+                prnWarningMessage(t, med, check),
+                [
+                  { text: t('common.cancel'), style: "cancel" },
+                  {
+                    text: t('prn.logAnyway'),
+                    style: "destructive",
+                    onPress: () => { logPRNDose(med, { force: true }); },
+                  },
+                ]
+              );
+              return;
             }
+            Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
           },
         },
       ]

--- a/app/medication/[id].tsx
+++ b/app/medication/[id].tsx
@@ -99,6 +99,8 @@ export default function EditMedicationScreen() {
     isPRN: medication.isPRN,
     photoUri: medication.photoUri,
     renewalDate: medication.renewalDate,
+    prnMaxPerDay: medication.prnMaxPerDay,
+    prnMinIntervalMinutes: medication.prnMinIntervalMinutes,
     schedules: schedules.map((s) => ({
       id: s.id,
       time: s.time,
@@ -126,6 +128,8 @@ export default function EditMedicationScreen() {
           isPRN: values.isPRN,
           photoUri: values.photoUri,
           renewalDate: values.renewalDate,
+          prnMaxPerDay: values.prnMaxPerDay,
+          prnMinIntervalMinutes: values.prnMinIntervalMinutes,
         },
         // Pass each schedule's id through so unchanged schedules keep their
         // identity (and their dose_logs) instead of being deleted + recreated

--- a/app/medication/new.tsx
+++ b/app/medication/new.tsx
@@ -31,6 +31,8 @@ export default function NewMedicationScreen() {
           isPRN: values.isPRN,
           photoUri: values.photoUri,
           renewalDate: values.renewalDate,
+          prnMaxPerDay: values.prnMaxPerDay,
+          prnMinIntervalMinutes: values.prnMinIntervalMinutes,
         },
         values.schedules.map((s) => ({ time: s.time, days: s.days }))
       );

--- a/components/MedicationForm.tsx
+++ b/components/MedicationForm.tsx
@@ -257,6 +257,9 @@ export interface MedicationFormValues {
   photoUri?: string;
   /** ISO date (YYYY-MM-DD) — optional prescription-renewal date. */
   renewalDate?: string;
+  /** PRN safety limits (F2). */
+  prnMaxPerDay?: number;
+  prnMinIntervalMinutes?: number;
 }
 
 interface MedicationFormProps {
@@ -336,6 +339,11 @@ export function MedicationForm({
       stockThreshStr: initialValues?.stockAlertThreshold != null ? String(initialValues.stockAlertThreshold) : "",
       photoUri: initialValues?.photoUri,
       renewalDate: initialValues?.renewalDate,
+      prnMaxStr: initialValues?.prnMaxPerDay != null ? String(initialValues.prnMaxPerDay) : "",
+      prnIntervalHoursStr:
+        initialValues?.prnMinIntervalMinutes != null
+          ? String(Math.round((initialValues.prnMinIntervalMinutes / 60) * 100) / 100)
+          : "",
     },
   });
 
@@ -416,6 +424,14 @@ export function MedicationForm({
       isPRN: data.repeatMode === "prn",
       photoUri: data.photoUri,
       renewalDate: data.renewalDate,
+      prnMaxPerDay:
+        data.repeatMode === "prn" && data.prnMaxStr?.trim()
+          ? Math.max(1, parseInt(data.prnMaxStr, 10))
+          : undefined,
+      prnMinIntervalMinutes:
+        data.repeatMode === "prn" && data.prnIntervalHoursStr?.trim()
+          ? Math.max(1, Math.round(parseFloat(data.prnIntervalHoursStr.replace(",", ".")) * 60))
+          : undefined,
     });
   };
 
@@ -810,6 +826,50 @@ export function MedicationForm({
           {repeatMode === "repeat" && <TipBlock text={t('form.tipRepeatDates')} theme={theme} />}
           {repeatMode === "once" && <TipBlock text={t('form.tipOnceDateRequired')} theme={theme} />}
           {repeatMode === "prn" && <TipBlock text={t('form.tipPRN')} theme={theme} />}
+
+          {/* PRN safety limits (F2) */}
+          {repeatMode === "prn" && (
+            <View className="bg-card rounded-2xl border border-border p-4 gap-3 mt-2">
+              <Text className="text-xs font-bold text-muted uppercase tracking-widest">
+                {t('form.prnLimitsSection')}
+              </Text>
+              <View>
+                <Text className="text-sm font-semibold text-text mb-1.5">{t('form.prnMax')}</Text>
+                <Controller
+                  control={control}
+                  name="prnMaxStr"
+                  render={({ field: { onChange, value } }) => (
+                    <TextInput
+                      value={value}
+                      onChangeText={onChange}
+                      placeholder={t('form.prnMaxPlaceholder')}
+                      placeholderTextColor={theme.muted}
+                      keyboardType="number-pad"
+                      className="border border-border rounded-xl px-3 py-2.5 text-text text-base bg-card-alt w-28"
+                    />
+                  )}
+                />
+              </View>
+              <View>
+                <Text className="text-sm font-semibold text-text mb-1.5">{t('form.prnInterval')}</Text>
+                <Controller
+                  control={control}
+                  name="prnIntervalHoursStr"
+                  render={({ field: { onChange, value } }) => (
+                    <TextInput
+                      value={value}
+                      onChangeText={onChange}
+                      placeholder={t('form.prnIntervalPlaceholder')}
+                      placeholderTextColor={theme.muted}
+                      keyboardType="decimal-pad"
+                      className="border border-border rounded-xl px-3 py-2.5 text-text text-base bg-card-alt w-28"
+                    />
+                  )}
+                />
+              </View>
+              <Text className="text-xs text-muted leading-4">{t('form.prnLimitsHint')}</Text>
+            </View>
+          )}
 
           {/* Date pickers for once / repeat */}
           {repeatMode === "once" && (

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -161,6 +161,8 @@ function toMedication(row: typeof schema.medications.$inferSelect): Medication {
     isPRN: row.isPRN,
     renewalDate: row.renewalDate ?? undefined,
     renewalNotifIds: row.renewalNotifIds ?? undefined,
+    prnMaxPerDay: row.prnMaxPerDay ?? undefined,
+    prnMinIntervalMinutes: row.prnMinIntervalMinutes ?? undefined,
   };
 }
 
@@ -279,7 +281,9 @@ export async function initDatabase(): Promise<void> {
       photo_uri     TEXT,
       is_prn        INTEGER NOT NULL DEFAULT 0,
       renewal_date  TEXT,
-      renewal_notif_ids TEXT
+      renewal_notif_ids TEXT,
+      prn_max_per_day INTEGER,
+      prn_min_interval_minutes INTEGER
     );
 
     CREATE TABLE IF NOT EXISTS schedules (
@@ -462,6 +466,17 @@ export async function initDatabase(): Promise<void> {
     }
     expoDb.execSync("PRAGMA user_version = 11");
   }
+
+  if (user_version < 12) {
+    // F2: PRN safety limits (max doses/day + minimum spacing).
+    for (const s of [
+      "ALTER TABLE medications ADD COLUMN prn_max_per_day INTEGER",
+      "ALTER TABLE medications ADD COLUMN prn_min_interval_minutes INTEGER",
+    ]) {
+      try { expoDb.execSync(s); } catch { /* exists */ }
+    }
+    expoDb.execSync("PRAGMA user_version = 12");
+  }
 }
 
 // ─── Medications ───────────────────────────────────────────────────────────
@@ -496,6 +511,8 @@ export async function insertMedication(med: Medication): Promise<void> {
     isPRN: med.isPRN ?? false,
     renewalDate: med.renewalDate ?? null,
     renewalNotifIds: med.renewalNotifIds ?? null,
+    prnMaxPerDay: med.prnMaxPerDay ?? null,
+    prnMinIntervalMinutes: med.prnMinIntervalMinutes ?? null,
   }).run();
 }
 
@@ -517,6 +534,8 @@ export async function updateMedication(med: Medication): Promise<void> {
     isPRN: med.isPRN ?? false,
     renewalDate: med.renewalDate ?? null,
     renewalNotifIds: med.renewalNotifIds ?? null,
+    prnMaxPerDay: med.prnMaxPerDay ?? null,
+    prnMinIntervalMinutes: med.prnMinIntervalMinutes ?? null,
   }).where(eq(schema.medications.id, med.id)).run();
 }
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -21,6 +21,8 @@ export const medications = sqliteTable("medications", {
   isPRN: integer("is_prn", { mode: "boolean" }).notNull().default(false),
   renewalDate: text("renewal_date"),
   renewalNotifIds: text("renewal_notif_ids"),
+  prnMaxPerDay: integer("prn_max_per_day"),
+  prnMinIntervalMinutes: integer("prn_min_interval_minutes"),
 });
 
 // ─── Schedules ─────────────────────────────────────────────────────────────

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -195,6 +195,12 @@ const en: TranslationShape = {
     fieldRenewal: "Prescription renewal (optional)",
     fieldRenewalHint: "We'll remind you 7 days before and on the day itself.",
     drugDbAttribution: "Suggestions: RxTerms (U.S. National Library of Medicine)",
+    prnLimitsSection: "Safety limits (optional)",
+    prnMax: "Maximum doses per day",
+    prnMaxPlaceholder: "e.g. 4",
+    prnInterval: "Minimum hours between doses",
+    prnIntervalPlaceholder: "e.g. 6",
+    prnLimitsHint: "If you try to log a dose over the limit we'll warn you first (you can still confirm).",
     sectionPhoto: "Photo (optional)",
     addPhoto: "Add photo",
     changePhoto: "Change photo",
@@ -496,6 +502,12 @@ const en: TranslationShape = {
   },
 
   // ─── Settings screen ──────────────────────────────────────────────────────
+  prn: {
+    limitTitle: "Dose limit reached",
+    limitMax: "You already logged {{count}} of {{max}} allowed doses today.",
+    limitSoon: "Too soon for another dose. Next allowed: {{time}}.",
+    logAnyway: "Log anyway",
+  },
   appLock: {
     enterPin: "Enter your PIN",
     wrongPin: "Wrong PIN",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -193,6 +193,12 @@ const es = {
     fieldRenewal: "Renovación de receta (opcional)",
     fieldRenewalHint: "Te avisamos 7 días antes y el mismo día.",
     drugDbAttribution: "Sugerencias: RxTerms (U.S. National Library of Medicine)",
+    prnLimitsSection: "Límites de seguridad (opcional)",
+    prnMax: "Máximo de dosis por día",
+    prnMaxPlaceholder: "ej: 4",
+    prnInterval: "Horas mínimas entre dosis",
+    prnIntervalPlaceholder: "ej: 6",
+    prnLimitsHint: "Si intentás registrar una dosis por encima del límite, te avisamos antes (podés confirmar igual).",
     sectionPhoto: "Foto (opcional)",
     addPhoto: "Agregar foto",
     changePhoto: "Cambiar foto",
@@ -494,6 +500,12 @@ const es = {
   },
 
   // ─── Settings screen ──────────────────────────────────────────────────────
+  prn: {
+    limitTitle: "Límite de dosis alcanzado",
+    limitMax: "Ya registraste {{count}} de {{max}} dosis permitidas hoy.",
+    limitSoon: "Muy pronto para otra dosis. Próxima permitida: {{time}}.",
+    logAnyway: "Registrar igual",
+  },
   appLock: {
     enterPin: "Ingresá tu PIN",
     wrongPin: "PIN incorrecto",

--- a/src/schemas/medication.ts
+++ b/src/schemas/medication.ts
@@ -23,6 +23,8 @@ export const medicationFormSchema = z
     stockThreshStr: z.string().optional().default(""),
     photoUri: z.string().optional(),
     renewalDate: z.string().optional(),
+    prnMaxStr: z.string().optional(),
+    prnIntervalHoursStr: z.string().optional(),
   })
   .superRefine((data, ctx) => {
     // Validate dosage is a positive number

--- a/src/services/prnLimits.ts
+++ b/src/services/prnLimits.ts
@@ -1,0 +1,90 @@
+/**
+ * PRN safety limits (F2): max doses per day + minimum spacing between doses.
+ *
+ * Pure functions — the medications slice runs the check before logging a PRN
+ * dose and the UI shows a WARNING with an explicit "log anyway" confirmation.
+ * We warn, we never hard-block: the user may be following updated doctor
+ * instructions the app doesn't know about.
+ */
+import { Medication, DoseLog } from "../types";
+
+export interface PrnLimitCheck {
+  /** True when either limit would be exceeded by logging now. */
+  blocked: boolean;
+  /** Daily-max exceeded. */
+  overMax: boolean;
+  /** Too soon after the previous dose. */
+  tooSoon: boolean;
+  /** Taken doses already logged today. */
+  takenToday: number;
+  /** When the next dose becomes allowed (interval limit), else null. */
+  nextAllowedAt: Date | null;
+}
+
+/** Local calendar date (YYYY-MM-DD) for a Date — mirrors utils.toDateString. */
+function localDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Evaluates the PRN limits for `medication` given its recent TAKEN logs
+ * (today + yesterday is enough for any realistic interval) at time `now`.
+ */
+export function checkPrnLimits(
+  medication: Medication,
+  recentLogs: DoseLog[],
+  now: Date = new Date()
+): PrnLimitCheck {
+  const taken = recentLogs.filter(
+    (l) => l.medicationId === medication.id && l.status === "taken" && l.takenAt
+  );
+
+  const today = localDate(now);
+  const takenToday = taken.filter((l) => l.scheduledDate === today).length;
+
+  const overMax =
+    medication.prnMaxPerDay != null &&
+    medication.prnMaxPerDay > 0 &&
+    takenToday >= medication.prnMaxPerDay;
+
+  let tooSoon = false;
+  let nextAllowedAt: Date | null = null;
+  if (medication.prnMinIntervalMinutes != null && medication.prnMinIntervalMinutes > 0) {
+    const lastTakenMs = taken.reduce((max, l) => {
+      const t = new Date(l.takenAt!).getTime();
+      return Number.isFinite(t) && t > max ? t : max;
+    }, 0);
+    if (lastTakenMs > 0) {
+      const allowedMs = lastTakenMs + medication.prnMinIntervalMinutes * 60_000;
+      if (now.getTime() < allowedMs) {
+        tooSoon = true;
+        nextAllowedAt = new Date(allowedMs);
+      }
+    }
+  }
+
+  return { blocked: overMax || tooSoon, overMax, tooSoon, takenToday, nextAllowedAt };
+}
+
+/** Builds the localized warning body shown before "log anyway". */
+export function prnWarningMessage(
+  t: (key: string, opts?: Record<string, unknown>) => string,
+  medication: Medication,
+  check: PrnLimitCheck
+): string {
+  const parts: string[] = [];
+  if (check.overMax) {
+    parts.push(
+      t("prn.limitMax", { count: check.takenToday, max: medication.prnMaxPerDay })
+    );
+  }
+  if (check.tooSoon && check.nextAllowedAt) {
+    const hh = String(check.nextAllowedAt.getHours()).padStart(2, "0");
+    const mm = String(check.nextAllowedAt.getMinutes()).padStart(2, "0");
+    parts.push(t("prn.limitSoon", { time: `${hh}:${mm}` }));
+  }
+  return parts.join("\n");
+}

--- a/src/store/slices/medications.ts
+++ b/src/store/slices/medications.ts
@@ -40,6 +40,7 @@ import {
   DAYS_AHEAD,
 } from "../../services/notifications";
 import { setMedicationRenewalNotifIds } from "../../db/database";
+import { checkPrnLimits } from "../../services/prnLimits";
 import { getDefaultSnoozeMinutes } from "../../services/snoozeSettings";
 
 export const createMedicationsSlice: StateCreator<AppState, [], [], MedicationsSlice> = (set, get) => ({
@@ -367,8 +368,22 @@ export const createMedicationsSlice: StateCreator<AppState, [], [], MedicationsS
 
   // ── Log PRN dose ──────────────────────────────────────────────────────
 
-  async logPRNDose(medication) {
+  async logPRNDose(medication, opts) {
     const now = new Date();
+
+    // PRN safety limits (F2): when configured, evaluate BEFORE logging and
+    // return the check so the UI can warn + require an explicit "log anyway"
+    // (opts.force). Yesterday+today covers any realistic min-interval window.
+    if (
+      !opts?.force &&
+      (medication.prnMaxPerDay != null || medication.prnMinIntervalMinutes != null)
+    ) {
+      const from = toDateString(new Date(now.getTime() - 86_400_000));
+      const recent = await getDoseLogsByDateRange(from, toDateString(now));
+      const check = checkPrnLimits(medication, recent, now);
+      if (check.blocked) return check;
+    }
+
     // Each PRN log gets a unique scheduleId so that multiple doses on the
     // same day are tracked as separate entries (not overwritten by upsert).
     const log: DoseLog = {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -39,7 +39,15 @@ export interface MedicationsSlice {
   revertSnooze: (dose: TodayDose) => Promise<void>;
   getHistoryLogs: (from: string, to: string) => Promise<DoseLog[]>;
   getSchedulesForMedication: (medicationId: string) => Schedule[];
-  logPRNDose: (medication: Medication) => Promise<void>;
+  /**
+   * Logs a PRN dose. When safety limits are configured and would be exceeded,
+   * returns the check WITHOUT logging — the UI warns and may retry with
+   * { force: true } after explicit user confirmation.
+   */
+  logPRNDose: (
+    medication: Medication,
+    opts?: { force?: boolean }
+  ) => Promise<import("../services/prnLimits").PrnLimitCheck | undefined>;
 }
 
 export interface AppointmentsSlice {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -61,6 +61,10 @@ export interface Medication {
   renewalDate?: string;
   /** Pipe-separated scheduled-notification ids for the renewal reminders. */
   renewalNotifIds?: string;
+  /** PRN safety: maximum doses per calendar day (optional). */
+  prnMaxPerDay?: number;
+  /** PRN safety: minimum minutes between doses (optional). */
+  prnMinIntervalMinutes?: number;
 }
 
 // ─── Schedule ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Phase-2 feature #1: **PRN safety limits** — a shared gap in the category (neither MyTherapy nor Medisafe enforce it) and a natural extension of our PRN lead.

- Optional per-med limits: **max doses/day** and **minimum hours between doses** (PRN meds only).
- Logging a dose over a limit warns with the exact reason ("3 of 3 today", "next allowed at 18:30") and requires an explicit **"Log anyway"** — warn, never hard-block.
- Cross-midnight spacing handled (yesterday's dose counts for the interval). DB migration v12.

Validation: Jest **207/207** (new 7-case suite), ESLint 0 errors, no new tsc errors vs main baseline, no native changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
