### PR TITLE
feat(insights): on-device adherence insights (F2)

### DIFF
--- a/__tests__/insights.test.ts
+++ b/__tests__/insights.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for on-device adherence insights (F2).
+ */
+import { computeInsights } from "../src/services/insights";
+import { DoseLog, Medication, DailyCheckin } from "../src/types";
+
+let seq = 0;
+const log = (
+  date: string,
+  time: string,
+  status: DoseLog["status"],
+  medicationId = "m1"
+): DoseLog => ({
+  id: `l${seq++}`,
+  medicationId,
+  scheduleId: "s1",
+  scheduledDate: date,
+  scheduledTime: time,
+  status,
+  takenAt: status === "taken" ? `${date}T${time}:00.000Z` : undefined,
+  createdAt: `${date}T00:00:00.000Z`,
+});
+
+const med = (id: string, name: string): Medication => ({
+  id,
+  name,
+  dosageAmount: 1,
+  dosageUnit: "comprimidos",
+  dosage: "1 comprimidos",
+  category: "otro",
+  color: "blue",
+  isActive: true,
+  createdAt: "2026-01-01T00:00:00.000Z",
+});
+
+const checkin = (date: string, mood: 1 | 2 | 3 | 4 | 5): DailyCheckin => ({
+  id: `c${seq++}`,
+  date,
+  mood,
+  symptoms: [],
+  createdAt: `${date}T00:00:00.000Z`,
+});
+
+describe("computeInsights", () => {
+  it("returns nulls with insufficient history", () => {
+    const r = computeInsights([log("2026-07-01", "08:00", "taken")], [], []);
+    expect(r.overallRate).toBeNull();
+    expect(r.worstBand).toBeNull();
+  });
+
+  it("flags the worst time band when meaningfully below overall", () => {
+    const logs: DoseLog[] = [];
+    // 10 morning doses all taken; 6 night doses mostly missed.
+    for (let d = 1; d <= 10; d++) logs.push(log(`2026-07-${String(d).padStart(2, "0")}`, "08:00", "taken"));
+    for (let d = 1; d <= 6; d++) logs.push(log(`2026-07-${String(d).padStart(2, "0")}`, "22:00", d <= 5 ? "missed" : "taken"));
+    const r = computeInsights(logs, [med("m1", "A")], []);
+    expect(r.worstBand?.band).toBe("night");
+    expect(r.worstBand?.rate).toBeCloseTo(1 / 6, 5);
+  });
+
+  it("flags low-adherence meds under 80% with enough doses", () => {
+    const logs: DoseLog[] = [];
+    for (let d = 1; d <= 6; d++) logs.push(log(`2026-07-0${d}`, "08:00", d <= 3 ? "taken" : "missed", "m1"));
+    for (let d = 1; d <= 6; d++) logs.push(log(`2026-07-0${d}`, "09:00", "taken", "m2"));
+    const r = computeInsights(logs, [med("m1", "Flojo"), med("m2", "Bien")], []);
+    expect(r.lowMeds).toHaveLength(1);
+    expect(r.lowMeds[0].name).toBe("Flojo");
+  });
+
+  it("mood link requires enough days on both sides and a meaningful gap", () => {
+    const logs: DoseLog[] = [];
+    const checkins: DailyCheckin[] = [];
+    // 5 full-adherence days (mood 4), 5 missed days (mood 2).
+    for (let d = 1; d <= 5; d++) {
+      const date = `2026-07-0${d}`;
+      logs.push(log(date, "08:00", "taken"), log(date, "20:00", "taken"));
+      checkins.push(checkin(date, 4));
+    }
+    for (let d = 10; d <= 14; d++) {
+      const date = `2026-07-${d}`;
+      logs.push(log(date, "08:00", "taken"), log(date, "20:00", "missed"));
+      checkins.push(checkin(date, 2));
+    }
+    const r = computeInsights(logs, [med("m1", "A")], checkins);
+    expect(r.mood).not.toBeNull();
+    expect(r.mood!.avgFullDays).toBe(4);
+    expect(r.mood!.avgMissedDays).toBe(2);
+  });
+
+  it("produces no band/weekday insight when everything is uniform", () => {
+    const logs: DoseLog[] = [];
+    for (let d = 1; d <= 14; d++) logs.push(log(`2026-07-${String(d).padStart(2, "0")}`, "08:00", "taken"));
+    const r = computeInsights(logs, [med("m1", "A")], []);
+    expect(r.overallRate).toBe(1);
+    expect(r.worstBand).toBeNull();
+    expect(r.worstWeekday).toBeNull();
+    expect(r.lowMeds).toEqual([]);
+  });
+});

--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -2,6 +2,7 @@ import { View, Text, ScrollView, TouchableOpacity, Animated, Alert } from "react
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import { AdBanner } from "../../components/AdBanner";
+import { InsightsCard } from "../../components/InsightsCard";
 import * as Haptics from "expo-haptics";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useFocusEffect } from "expo-router";
@@ -425,6 +426,8 @@ export default function HistoryScreen() {
         showsVerticalScrollIndicator={false}
         ListHeaderComponent={
           <>
+            {/* On-device adherence insights (F2) — hides itself without data */}
+            <InsightsCard />
             {/* Month heatmap */}
             {viewMode === "month" && (
               loading

--- a/components/InsightsCard.tsx
+++ b/components/InsightsCard.tsx
@@ -1,0 +1,111 @@
+/**
+ * InsightsCard (F2): the single, focused insights surface — rendered at the
+ * top of the History tab. Computes 30-day patterns fully on-device via
+ * src/services/insights.ts and hides itself entirely when there is nothing
+ * meaningful to say (see the honesty thresholds in the service).
+ */
+import { View, Text } from "react-native";
+import { useState, useCallback } from "react";
+import { useFocusEffect } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+import { useTranslation } from "../src/i18n";
+import { useAppTheme } from "../src/hooks/useAppTheme";
+import { useAppStore } from "../src/store";
+import { getDoseLogsByDateRange, getDailyCheckins } from "../src/db/database";
+import { computeInsights, AdherenceInsights } from "../src/services/insights";
+import { toDateString } from "../src/utils";
+
+const DAYS = 30;
+
+function InsightRow({ icon, color, text }: { icon: React.ComponentProps<typeof Ionicons>["name"]; color: string; text: string }) {
+  return (
+    <View className="flex-row items-start gap-2.5 py-1.5">
+      <Ionicons name={icon} size={16} color={color} style={{ marginTop: 1 }} />
+      <Text className="text-[13px] text-text flex-1 leading-5">{text}</Text>
+    </View>
+  );
+}
+
+export function InsightsCard() {
+  const { t } = useTranslation();
+  const theme = useAppTheme();
+  const medications = useAppStore((s) => s.medications);
+  const [insights, setInsights] = useState<AdherenceInsights | null>(null);
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false;
+      (async () => {
+        try {
+          const to = toDateString(new Date());
+          const from = toDateString(new Date(Date.now() - DAYS * 86_400_000));
+          const [logs, checkins] = await Promise.all([
+            getDoseLogsByDateRange(from, to),
+            getDailyCheckins(from, to),
+          ]);
+          if (!cancelled) setInsights(computeInsights(logs, medications, checkins));
+        } catch {
+          if (!cancelled) setInsights(null);
+        }
+      })();
+      return () => { cancelled = true; };
+    }, [medications])
+  );
+
+  if (!insights || insights.overallRate == null) return null;
+
+  const rows: { icon: React.ComponentProps<typeof Ionicons>["name"]; color: string; text: string }[] = [];
+
+  if (insights.worstBand) {
+    rows.push({
+      icon: "time-outline",
+      color: theme.warning,
+      text: t("insights.worstBand", {
+        band: t(`insights.band_${insights.worstBand.band}`),
+        rate: Math.round(insights.worstBand.rate * 100),
+      }),
+    });
+  }
+  if (insights.worstWeekday) {
+    rows.push({
+      icon: "calendar-outline",
+      color: theme.warning,
+      text: t("insights.worstWeekday", {
+        day: t(`insights.weekday_${insights.worstWeekday.weekday}`),
+        rate: Math.round(insights.worstWeekday.rate * 100),
+      }),
+    });
+  }
+  for (const med of insights.lowMeds) {
+    rows.push({
+      icon: "medkit-outline",
+      color: theme.danger,
+      text: t("insights.lowMed", { name: med.name, rate: Math.round(med.rate * 100), taken: med.taken, total: med.total }),
+    });
+  }
+  if (insights.mood) {
+    rows.push({
+      icon: "happy-outline",
+      color: theme.primary,
+      text: t("insights.moodLink", {
+        full: insights.mood.avgFullDays,
+        missed: insights.mood.avgMissedDays,
+      }),
+    });
+  }
+
+  if (rows.length === 0) return null;
+
+  return (
+    <View className="mx-5 mb-4 rounded-2xl bg-card border border-border p-4">
+      <View className="flex-row items-center gap-2 mb-1">
+        <Ionicons name="bulb-outline" size={16} color={theme.primary} />
+        <Text className="text-sm font-bold text-text">{t("insights.title", { days: DAYS })}</Text>
+      </View>
+      {rows.map((r, i) => (
+        <InsightRow key={i} icon={r.icon} color={r.color} text={r.text} />
+      ))}
+      <Text className="text-[10px] text-muted mt-1.5">{t("insights.disclaimer")}</Text>
+    </View>
+  );
+}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -502,6 +502,24 @@ const en: TranslationShape = {
   },
 
   // ─── Settings screen ──────────────────────────────────────────────────────
+  insights: {
+    title: "Your patterns ({{days}} days)",
+    band_morning: "morning",
+    band_afternoon: "afternoon",
+    band_night: "night",
+    worstBand: "Your {{band}} doses are the ones you miss most ({{rate}}% taken).",
+    worstWeekday: "{{day}} are your hardest day ({{rate}}% taken).",
+    lowMed: "{{name}} is lagging: {{taken}} of {{total}} doses taken ({{rate}}%).",
+    moodLink: "On days with every dose taken your mood averaged {{full}}/5, vs {{missed}}/5 on days with missed doses.",
+    weekday_0: "Sundays",
+    weekday_1: "Mondays",
+    weekday_2: "Tuesdays",
+    weekday_3: "Wednesdays",
+    weekday_4: "Thursdays",
+    weekday_5: "Fridays",
+    weekday_6: "Saturdays",
+    disclaimer: "Observations computed on your device from your own log. They do not imply causation.",
+  },
   interactions: {
     dupTitle: "Repeated ingredient",
     dupLine: "{{name}} also contains: {{ingredients}}",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -500,6 +500,24 @@ const es = {
   },
 
   // ─── Settings screen ──────────────────────────────────────────────────────
+  insights: {
+    title: "Tus patrones ({{days}} días)",
+    band_morning: "la mañana",
+    band_afternoon: "la tarde",
+    band_night: "la noche",
+    worstBand: "Las dosis de {{band}} son las que más se te escapan ({{rate}}% tomadas).",
+    worstWeekday: "Los {{day}} son tu día más difícil ({{rate}}% tomadas).",
+    lowMed: "{{name}} viene flojo: {{taken}} de {{total}} dosis tomadas ({{rate}}%).",
+    moodLink: "En días con todas las dosis tomadas tu ánimo promedió {{full}}/5, contra {{missed}}/5 en días con dosis perdidas.",
+    weekday_0: "domingos",
+    weekday_1: "lunes",
+    weekday_2: "martes",
+    weekday_3: "miércoles",
+    weekday_4: "jueves",
+    weekday_5: "viernes",
+    weekday_6: "sábados",
+    disclaimer: "Observaciones calculadas en tu dispositivo sobre tu propio registro. No implican causalidad.",
+  },
   interactions: {
     dupTitle: "Ingrediente repetido",
     dupLine: "{{name}} también contiene: {{ingredients}}",

--- a/src/services/insights.ts
+++ b/src/services/insights.ts
@@ -1,0 +1,167 @@
+/**
+ * On-device adherence insights (F2) — pure computation over local history.
+ *
+ * Honesty thresholds everywhere: an insight is only produced when there is
+ * enough data AND the signal is meaningful (see constants). With thin data
+ * everything returns null and the UI hides the card entirely — no noise,
+ * no fake certainty. The mood link is an OBSERVATION, never causation.
+ */
+import { DoseLog, Medication, DailyCheckin } from "../types";
+
+// Minimum evidence requirements.
+const MIN_TOTAL_DOSES = 10;
+const MIN_BUCKET_DOSES = 5;
+const MIN_WEEKDAY_DOSES = 3;
+const MIN_MED_DOSES = 5;
+const MIN_MOOD_DAYS = 5;
+/** A bucket must underperform the overall rate by ≥ this many points. */
+const MEANINGFUL_GAP = 0.15;
+const LOW_MED_RATE = 0.8;
+const MIN_MOOD_DIFF = 0.5;
+
+export type TimeBand = "morning" | "afternoon" | "night";
+
+export interface TimeBandInsight { band: TimeBand; rate: number; total: number }
+export interface WeekdayInsight { weekday: number; rate: number; total: number }
+export interface MedAdherenceInsight { name: string; rate: number; taken: number; total: number }
+export interface MoodInsight {
+  avgFullDays: number;
+  avgMissedDays: number;
+  fullDays: number;
+  missedDays: number;
+}
+
+export interface AdherenceInsights {
+  /** null when there isn't enough history to say anything. */
+  overallRate: number | null;
+  totalDoses: number;
+  worstBand: TimeBandInsight | null;
+  worstWeekday: WeekdayInsight | null;
+  /** Up to 2 meds under LOW_MED_RATE, worst first. */
+  lowMeds: MedAdherenceInsight[];
+  mood: MoodInsight | null;
+}
+
+function bandOf(scheduledTime: string): TimeBand {
+  const h = Number(scheduledTime.split(":")[0]);
+  if (h >= 5 && h < 12) return "morning";
+  if (h >= 12 && h < 19) return "afternoon";
+  return "night";
+}
+
+function weekdayOf(scheduledDate: string): number {
+  const [y, m, d] = scheduledDate.split("-").map(Number);
+  return new Date(y, m - 1, d).getDay();
+}
+
+interface Bucket { taken: number; total: number }
+const rate = (b: Bucket) => (b.total > 0 ? b.taken / b.total : 0);
+const bump = (map: Map<string | number, Bucket>, key: string | number, taken: boolean) => {
+  const b = map.get(key) ?? { taken: 0, total: 0 };
+  b.total += 1;
+  if (taken) b.taken += 1;
+  map.set(key, b);
+};
+
+export function computeInsights(
+  logs: DoseLog[],
+  medications: Medication[],
+  checkins: DailyCheckin[]
+): AdherenceInsights {
+  // Only resolved doses count — pending says nothing about behaviour.
+  const resolved = logs.filter(
+    (l) => l.status === "taken" || l.status === "skipped" || l.status === "missed"
+  );
+  const empty: AdherenceInsights = {
+    overallRate: null,
+    totalDoses: resolved.length,
+    worstBand: null,
+    worstWeekday: null,
+    lowMeds: [],
+    mood: null,
+  };
+  if (resolved.length < MIN_TOTAL_DOSES) return empty;
+
+  const takenCount = resolved.filter((l) => l.status === "taken").length;
+  const overall = takenCount / resolved.length;
+
+  // ── Time-of-day pattern ──────────────────────────────────────────────────
+  const bands = new Map<string | number, Bucket>();
+  for (const l of resolved) bump(bands, bandOf(l.scheduledTime), l.status === "taken");
+  let worstBand: TimeBandInsight | null = null;
+  for (const [band, b] of bands) {
+    if (b.total < MIN_BUCKET_DOSES) continue;
+    const r = rate(b);
+    if (r <= overall - MEANINGFUL_GAP && (!worstBand || r < worstBand.rate)) {
+      worstBand = { band: band as TimeBand, rate: r, total: b.total };
+    }
+  }
+
+  // ── Weekday pattern ──────────────────────────────────────────────────────
+  const days = new Map<string | number, Bucket>();
+  for (const l of resolved) bump(days, weekdayOf(l.scheduledDate), l.status === "taken");
+  let worstWeekday: WeekdayInsight | null = null;
+  for (const [wd, b] of days) {
+    if (b.total < MIN_WEEKDAY_DOSES) continue;
+    const r = rate(b);
+    if (r <= overall - MEANINGFUL_GAP && (!worstWeekday || r < worstWeekday.rate)) {
+      worstWeekday = { weekday: wd as number, rate: r, total: b.total };
+    }
+  }
+
+  // ── Per-medication adherence ─────────────────────────────────────────────
+  const byMed = new Map<string | number, Bucket>();
+  for (const l of resolved) bump(byMed, l.medicationId, l.status === "taken");
+  const nameById = new Map(medications.map((m) => [m.id, m.name]));
+  const lowMeds: MedAdherenceInsight[] = Array.from(byMed.entries())
+    .filter(([, b]) => b.total >= MIN_MED_DOSES && rate(b) < LOW_MED_RATE)
+    .map(([id, b]) => ({
+      name: nameById.get(id as string) ?? String(id),
+      rate: rate(b),
+      taken: b.taken,
+      total: b.total,
+    }))
+    .sort((a, b) => a.rate - b.rate)
+    .slice(0, 2);
+
+  // ── Mood observation (full-adherence days vs days with a missed dose) ────
+  let mood: MoodInsight | null = null;
+  const moodByDate = new Map(checkins.map((c) => [c.date, c.mood]));
+  const byDate = new Map<string, { anyMissed: boolean; allTaken: boolean }>();
+  for (const l of resolved) {
+    const e = byDate.get(l.scheduledDate) ?? { anyMissed: false, allTaken: true };
+    if (l.status === "missed") e.anyMissed = true;
+    if (l.status !== "taken") e.allTaken = false;
+    byDate.set(l.scheduledDate, e);
+  }
+  const fullMoods: number[] = [];
+  const missedMoods: number[] = [];
+  for (const [date, e] of byDate) {
+    const m = moodByDate.get(date);
+    if (m == null) continue;
+    if (e.allTaken) fullMoods.push(m);
+    else if (e.anyMissed) missedMoods.push(m);
+  }
+  if (fullMoods.length >= MIN_MOOD_DAYS && missedMoods.length >= MIN_MOOD_DAYS) {
+    const avg = (a: number[]) => a.reduce((s, v) => s + v, 0) / a.length;
+    const avgFull = avg(fullMoods);
+    const avgMissed = avg(missedMoods);
+    if (Math.abs(avgFull - avgMissed) >= MIN_MOOD_DIFF) {
+      mood = {
+        avgFullDays: Math.round(avgFull * 10) / 10,
+        avgMissedDays: Math.round(avgMissed * 10) / 10,
+        fullDays: fullMoods.length,
+        missedDays: missedMoods.length,
+      };
+    }
+  }
+
+  return {
+    overallRate: overall,
+    totalDoses: resolved.length,
+    worstBand,
+    worstWeekday,
+    lowMeds,
+    mood,
+  };
+}


### PR DESCRIPTION
Phase-2 feature #3: **on-device adherence insights** — the retention lever from the backlog, computed 100% locally (MyTherapy does this server-side).

- 30-day patterns with hard honesty thresholds: worst **time-of-day band**, hardest **weekday**, **low-adherence meds** (<80%), and a **mood observation** (avg mood on full-adherence days vs days with missed doses; requires ≥5 days on each side and a ≥0.5 gap).
- Single focused card at the top of History that **hides itself entirely** when there's nothing meaningful to say — the anti-noise mandate, enforced in code.
- Explicit non-causation disclaimer.

Validation: Jest **217/217** (new 5-case suite), ESLint 0 errors, no new tsc errors, no native changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
