### PR TITLE
feat(health): sync de vitales a Health Connect (F2)

### DIFF
--- a/__tests__/healthSync.test.ts
+++ b/__tests__/healthSync.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for the Health Connect record mapping (F2).
+ */
+import { buildHealthConnectRecord } from "../src/services/healthSync";
+import { HealthMeasurement } from "../src/types";
+
+const m = (over: Partial<HealthMeasurement>): HealthMeasurement => ({
+  id: "h1",
+  type: "weight",
+  value1: 70,
+  measuredAt: "2026-07-22T10:00:00.000Z",
+  createdAt: "2026-07-22T10:00:00.000Z",
+  ...over,
+});
+
+describe("buildHealthConnectRecord", () => {
+  it("maps blood pressure with both values in mmHg", () => {
+    const r = buildHealthConnectRecord(m({ type: "blood_pressure", value1: 120, value2: 80 }))!;
+    expect(r.recordType).toBe("BloodPressure");
+    expect(r.systolic).toEqual({ value: 120, unit: "millimetersOfMercury" });
+    expect(r.diastolic).toEqual({ value: 80, unit: "millimetersOfMercury" });
+  });
+
+  it("rejects blood pressure without diastolic", () => {
+    expect(buildHealthConnectRecord(m({ type: "blood_pressure", value1: 120 }))).toBeNull();
+  });
+
+  it("maps glucose in mg/dL with unknown context fields", () => {
+    const r = buildHealthConnectRecord(m({ type: "glucose", value1: 95 }))!;
+    expect(r.recordType).toBe("BloodGlucose");
+    expect(r.level).toEqual({ value: 95, unit: "milligramsPerDeciliter" });
+    expect(r.specimenSource).toBe(0);
+  });
+
+  it("maps weight in kilograms", () => {
+    const r = buildHealthConnectRecord(m({ type: "weight", value1: 70.5 }))!;
+    expect(r.weight).toEqual({ value: 70.5, unit: "kilograms" });
+  });
+
+  it("maps SpO2 as a percentage", () => {
+    const r = buildHealthConnectRecord(m({ type: "spo2", value1: 97 }))!;
+    expect(r).toMatchObject({ recordType: "OxygenSaturation", percentage: 97 });
+  });
+
+  it("maps heart rate as a 1-second interval series with one sample", () => {
+    const r = buildHealthConnectRecord(m({ type: "heart_rate", value1: 68 }))!;
+    expect(r.recordType).toBe("HeartRate");
+    expect(r.startTime).toBe("2026-07-22T10:00:00.000Z");
+    expect(r.endTime).toBe("2026-07-22T10:00:01.000Z");
+    expect(r.samples).toEqual([{ time: "2026-07-22T10:00:00.000Z", beatsPerMinute: 68 }]);
+  });
+});

--- a/app.json
+++ b/app.json
@@ -75,6 +75,7 @@
         }
       ],
       "expo-secure-store",
+      "react-native-health-connect",
       [
         "react-native-google-mobile-ads",
         {
@@ -101,7 +102,8 @@
         "expo-build-properties",
         {
           "android": {
-            "enableProguardInReleaseBuilds": false
+            "enableProguardInReleaseBuilds": false,
+            "minSdkVersion": 26
           }
         }
       ],

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -28,6 +28,7 @@ import {
   changePin,
 } from "../../src/services/appLock";
 import { PinModal } from "../../components/PinModal";
+import { isHealthSyncSupported, isHealthSyncEnabled, enableHealthSync, disableHealthSync } from "../../src/services/healthSync";
 
 // ─── Sub-components ────────────────────────────────────────────────────────
 
@@ -183,6 +184,27 @@ export default function SettingsScreen() {
     Haptics.selectionAsync();
     setBiometricOn(on);
     setBiometricPreferred(on);
+  };
+
+  // Health Connect sync (F2)
+  const [healthSyncOn, setHealthSyncOn] = useState(isHealthSyncEnabled);
+
+  const handleHealthSyncToggle = async (on: boolean) => {
+    Haptics.selectionAsync();
+    if (!on) {
+      disableHealthSync();
+      setHealthSyncOn(false);
+      return;
+    }
+    // Optimistic flip while the permission sheet is up; revert on refusal.
+    setHealthSyncOn(true);
+    const granted = await enableHealthSync();
+    if (!granted) {
+      setHealthSyncOn(false);
+      showToast(t("settings.healthSyncDenied"), "error");
+    } else {
+      showToast(t("settings.healthSyncEnabled"), "success");
+    }
   };
 
   const handlePinSuccess = async (pin: string) => {
@@ -511,6 +533,24 @@ export default function SettingsScreen() {
 
         {/* ─── Your data ─── */}
         <SectionHeader title={t("settings.sectionData")} />
+        {/* Health Connect one-way vitals sync (F2, Android only) */}
+        {isHealthSyncSupported() && (
+          <View className="mx-5 mb-2 rounded-2xl overflow-hidden bg-card" style={{ shadowColor: "#000", shadowOpacity: 0.04, shadowRadius: 8, elevation: 2 }}>
+            <View className="flex-row items-center px-4 py-3.5 gap-3">
+              <Ionicons name="fitness-outline" size={20} color={theme.accent} />
+              <View className="flex-1">
+                <Text className="text-[15px] font-semibold text-text">{t("settings.healthSync")}</Text>
+                <Text className="text-xs text-muted mt-0.5 leading-4">{t("settings.healthSyncSubtitle")}</Text>
+              </View>
+              <Switch
+                value={healthSyncOn}
+                onValueChange={handleHealthSyncToggle}
+                trackColor={{ false: undefined, true: theme.primary }}
+                accessibilityLabel={t("settings.healthSync")}
+              />
+            </View>
+          </View>
+        )}
         {/* Local-first nudge: users are never told their data isn't backed up
             anywhere and is lost with the phone (audit UX I11). */}
         <View className="mx-5 mb-2 flex-row items-start gap-2 bg-blue-50 dark:bg-blue-950/30 rounded-xl px-3 py-2.5">

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -61,6 +61,14 @@ jest.mock("expo-crypto", () => ({
   getRandomBytes: jest.fn((n: number) => new Uint8Array(n).fill(7)),
 }));
 
+// ─── react-native-health-connect ───────────────────────────────────────────
+jest.mock("react-native-health-connect", () => ({
+  initialize: jest.fn().mockResolvedValue(true),
+  getSdkStatus: jest.fn().mockResolvedValue(3),
+  requestPermission: jest.fn().mockResolvedValue([]),
+  insertRecords: jest.fn().mockResolvedValue([]),
+}));
+
 // ─── expo-local-authentication ─────────────────────────────────────────────
 jest.mock("expo-local-authentication", () => ({
   hasHardwareAsync: jest.fn().mockResolvedValue(false),

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "react-native-copilot": "^3.3.3",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-google-mobile-ads": "^15.7.0",
+        "react-native-health-connect": "^3.5.3",
         "react-native-maps": "1.20.1",
         "react-native-mmkv": "^4.2.0",
         "react-native-reanimated": "~4.1.1",
@@ -16564,6 +16565,27 @@
         "expo": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-health-connect": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/react-native-health-connect/-/react-native-health-connect-3.5.3.tgz",
+      "integrity": "sha512-lco68RbMaWpvElED3/obXTJSzoWopo9k5loN/+1zSdr3iT4STp7BaoziyPx0DIyW1a6DF/lvMesXIubWKE1Srw==",
+      "license": "MIT",
+      "workspaces": [
+        "example",
+        "docs"
+      ],
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/matinzd/react-native-health-connect?sponsor=1"
+      },
+      "peerDependencies": {
+        "@expo/config-plugins": ">= 6.0.2",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-is-edge-to-edge": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-native-copilot": "^3.3.3",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-google-mobile-ads": "^15.7.0",
+    "react-native-health-connect": "^3.5.3",
     "react-native-maps": "1.20.1",
     "react-native-mmkv": "^4.2.0",
     "react-native-reanimated": "~4.1.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,6 +43,7 @@ export const STORAGE_KEYS = {
   APP_LOCK_ENABLED:           "@pilloclock/app_lock_enabled",
   APP_LOCK_BIOMETRIC:         "@pilloclock/app_lock_biometric",
   SENIOR_MODE:                "@pilloclock/senior_mode",
+  HEALTH_SYNC:                "@pilloclock/health_sync",
   RECENT_COLORS:            "custom_colors_recent",
   // Legacy keys kept for migration only (notifications.ts)
   NOTIF_MAP:                "@pilloclock/notif_map",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -590,6 +590,11 @@ const en: TranslationShape = {
     snoozeDefaultTitle: "Default interval",
     snoozeDefaultSubtitle: "How long a dose is snoozed with the notification's ⏰ button",
     snoozeOptionA11y: "Default snooze {{minutes}} minutes",
+    // Health Connect
+    healthSync: "Sync with Health Connect",
+    healthSyncSubtitle: "Copies your measurements (BP, glucose, weight, SpO₂, heart rate) to your device's health store",
+    healthSyncEnabled: "Health Connect sync enabled",
+    healthSyncDenied: "Health Connect permissions were not granted",
     // Security
     sectionSecurity: "Security",
     appLockTitle: "App lock",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -588,6 +588,11 @@ const es = {
     snoozeDefaultTitle: "Intervalo por defecto",
     snoozeDefaultSubtitle: "Cuánto se pospone una dosis con el botón ⏰ de la notificación",
     snoozeOptionA11y: "Posponer por defecto {{minutes}} minutos",
+    // Health Connect
+    healthSync: "Sincronizar con Health Connect",
+    healthSyncSubtitle: "Copia tus mediciones (presión, glucosa, peso, SpO₂, pulso) al almacén de salud de tu dispositivo",
+    healthSyncEnabled: "Sincronización con Health Connect activada",
+    healthSyncDenied: "No se otorgaron permisos de Health Connect",
     // Security
     sectionSecurity: "Seguridad",
     appLockTitle: "Bloqueo de app",

--- a/src/services/healthSync.ts
+++ b/src/services/healthSync.ts
@@ -1,0 +1,123 @@
+/**
+ * Health Connect vitals sync (F2) — one-way push of the user's measurements
+ * into Android's ON-DEVICE Health Connect store. No backend involved: Health
+ * Connect is a local store, so this stays inside the local-first posture.
+ *
+ * Scope v1: Android only (our testing track). iOS/HealthKit is a planned
+ * follow-up — do not fake support. Opt-in via Settings; permissions are
+ * requested when the user enables the toggle.
+ */
+import { Platform } from "react-native";
+import { storage } from "../storage";
+import { STORAGE_KEYS } from "../config";
+import { HealthMeasurement } from "../types";
+
+// Lazy require: the native module must not load unless the feature is used.
+type HC = typeof import("react-native-health-connect");
+function hc(): HC {
+  return require("react-native-health-connect") as HC;
+}
+
+export function isHealthSyncSupported(): boolean {
+  return Platform.OS === "android";
+}
+
+export function isHealthSyncEnabled(): boolean {
+  return isHealthSyncSupported() && storage.getString(STORAGE_KEYS.HEALTH_SYNC) === "1";
+}
+
+const WRITE_PERMISSIONS = [
+  { accessType: "write", recordType: "BloodPressure" },
+  { accessType: "write", recordType: "BloodGlucose" },
+  { accessType: "write", recordType: "Weight" },
+  { accessType: "write", recordType: "OxygenSaturation" },
+  { accessType: "write", recordType: "HeartRate" },
+] as const;
+
+/**
+ * Initializes Health Connect and requests write permissions.
+ * Returns true (and persists the flag) when at least one was granted.
+ */
+export async function enableHealthSync(): Promise<boolean> {
+  if (!isHealthSyncSupported()) return false;
+  try {
+    const ok = await hc().initialize();
+    if (!ok) return false;
+    const granted = await hc().requestPermission(
+      WRITE_PERMISSIONS as unknown as Parameters<HC["requestPermission"]>[0]
+    );
+    if (!granted || granted.length === 0) return false;
+    storage.set(STORAGE_KEYS.HEALTH_SYNC, "1");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function disableHealthSync(): void {
+  storage.delete(STORAGE_KEYS.HEALTH_SYNC);
+}
+
+/**
+ * Pure mapping: our measurement → a Health Connect record (null when the
+ * type can't be represented). Exported for unit tests.
+ */
+export function buildHealthConnectRecord(m: HealthMeasurement): Record<string, unknown> | null {
+  const time = m.measuredAt;
+  switch (m.type) {
+    case "blood_pressure":
+      if (m.value2 == null) return null;
+      return {
+        recordType: "BloodPressure",
+        time,
+        systolic: { value: m.value1, unit: "millimetersOfMercury" },
+        diastolic: { value: m.value2, unit: "millimetersOfMercury" },
+        bodyPosition: 0, // unknown
+        measurementLocation: 0, // unknown
+      };
+    case "glucose":
+      return {
+        recordType: "BloodGlucose",
+        time,
+        level: { value: m.value1, unit: "milligramsPerDeciliter" },
+        specimenSource: 0,
+        mealType: 0,
+        relationToMeal: 0,
+      };
+    case "weight":
+      return {
+        recordType: "Weight",
+        time,
+        weight: { value: m.value1, unit: "kilograms" },
+      };
+    case "spo2":
+      return { recordType: "OxygenSaturation", time, percentage: m.value1 };
+    case "heart_rate":
+      return {
+        recordType: "HeartRate",
+        startTime: time,
+        // Instantaneous reading modeled as a 1-second interval with one sample
+        // (Health Connect requires endTime > startTime on series records).
+        endTime: new Date(new Date(time).getTime() + 1000).toISOString(),
+        samples: [{ time, beatsPerMinute: m.value1 }],
+      };
+    default:
+      return null;
+  }
+}
+
+/**
+ * Fire-and-forget push of a saved measurement. Never throws — a sync failure
+ * must not affect the local save.
+ */
+export async function syncMeasurementToHealthConnect(m: HealthMeasurement): Promise<void> {
+  if (!isHealthSyncEnabled()) return;
+  const record = buildHealthConnectRecord(m);
+  if (!record) return;
+  try {
+    await hc().initialize();
+    await hc().insertRecords([record as never]);
+  } catch (e) {
+    console.warn("[healthSync] insert failed", e);
+  }
+}

--- a/src/store/slices/health.ts
+++ b/src/store/slices/health.ts
@@ -9,6 +9,7 @@ import {
   upsertDailyCheckin,
 } from "../../db/database";
 import { generateId, toISOString } from "../../utils";
+import { syncMeasurementToHealthConnect } from "../../services/healthSync";
 
 export const createHealthSlice: StateCreator<AppState, [], [], HealthSlice> = (set) => ({
   healthMeasurements: [],
@@ -27,6 +28,8 @@ export const createHealthSlice: StateCreator<AppState, [], [], HealthSlice> = (s
     };
     await insertHealthMeasurement(m);
     set((s) => ({ healthMeasurements: [m, ...s.healthMeasurements] }));
+    // One-way Health Connect push (F2) — fire-and-forget, never blocks the save.
+    syncMeasurementToHealthConnect(m).catch(() => {});
   },
 
   async deleteHealthMeasurement(id) {


### PR DESCRIPTION
## Qué hace

Sincronización **opt-in y unidireccional** de mediciones de salud hacia **Health Connect** (solo Android), Fase 2 del backlog.

- `src/services/healthSync.ts`: mapeo puro medición → registro HC (presión arterial mmHg, glucosa mg/dL, peso kg, SpO2 %, frecuencia cardíaca como serie de intervalo de 1s) + `enableHealthSync` (initialize + permisos WRITE) / `disableHealthSync` / `syncMeasurementToHealthConnect` fire-and-forget.
- El slice de salud sincroniza cada medición nueva al guardarla; si HC no está disponible o el toggle está apagado, no hace nada (fail-closed).
- Ajustes → Tus datos: toggle "Sincronizar con Health Connect" (solo visible en Android) con flip optimista y revert si se niegan permisos. i18n ES/EN.

## Cambios nativos (android/ persistente, no versionado)

- **minSdk 24 → 26**: `connect-client` de Health Connect exige 26. Android 7.x es <1.5% del mercado en 2026 y HC nunca funcionó ahí. Reflejado en `app.json` (expo-build-properties) y `android/gradle.properties`.
- Manifest: 5 permisos `android.permission.health.WRITE_*` + intent-filter `ACTION_SHOW_PERMISSIONS_RATIONALE` en MainActivity.

## Validación

- Jest **223/223**, tsc y eslint limpios (baseline pre-existente aparte).
- `:app:compileReleaseJavaWithJavac` **BUILD SUCCESSFUL** con minSdk 26.
- Pendiente validación en dispositivo con el próximo build de testers (flujo de permisos + registros visibles en la app Health Connect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
