### PR TITLE
feat(injectables): rotación de sitio + countdown semanal para GLP-1 (F3)

### DIFF
--- a/__tests__/injectionSites.test.ts
+++ b/__tests__/injectionSites.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Injection-site rotation + weekly countdown (F3 injectables).
+ */
+import { suggestNextSite, nextDueDate, INJECTION_SITES } from "../src/services/injectionSites";
+import { makeMedication, makeSchedule, makeDoseLog } from "./factories";
+
+describe("suggestNextSite", () => {
+  it("suggests the first site with no history", () => {
+    expect(suggestNextSite([])).toBe("abdomen_l");
+  });
+
+  it("suggests the first never-used site", () => {
+    const logs = [
+      makeDoseLog({ id: "l1", scheduledDate: "2026-07-01", injectionSite: "abdomen_l" }),
+      makeDoseLog({ id: "l2", scheduledDate: "2026-07-08", injectionSite: "abdomen_r" }),
+    ];
+    expect(suggestNextSite(logs)).toBe("thigh_l");
+  });
+
+  it("falls back to the least-recently-used site when all were used", () => {
+    const logs = INJECTION_SITES.map((site, i) =>
+      makeDoseLog({
+        id: `l${i}`,
+        scheduledDate: `2026-07-${String(i + 1).padStart(2, "0")}`,
+        injectionSite: site,
+      })
+    );
+    // abdomen_l was used on 07-01 → oldest → suggested again.
+    expect(suggestNextSite(logs)).toBe("abdomen_l");
+  });
+
+  it("ignores logs without a site", () => {
+    const logs = [
+      makeDoseLog({ id: "l1", scheduledDate: "2026-07-01", injectionSite: "abdomen_l" }),
+      makeDoseLog({ id: "l2", scheduledDate: "2026-07-08" }),
+    ];
+    expect(suggestNextSite(logs)).toBe("abdomen_r");
+  });
+});
+
+describe("nextDueDate", () => {
+  // Wednesday 2026-07-22.
+  const NOW = new Date(2026, 6, 22, 12);
+
+  it("finds the next weekly occurrence", () => {
+    const med = makeMedication({ id: "m1", createdAt: "2026-06-01T00:00:00.000Z" });
+    const sched = makeSchedule({ medicationId: "m1", days: [5] }); // Fridays
+    expect(nextDueDate(med, [sched], NOW)).toEqual({ date: "2026-07-24", inDays: 2 });
+  });
+
+  it("returns null without active schedules", () => {
+    const med = makeMedication({ id: "m1" });
+    expect(nextDueDate(med, [], NOW)).toBeNull();
+    const inactive = makeSchedule({ medicationId: "m1", days: [5], isActive: false });
+    expect(nextDueDate(med, [inactive], NOW)).toBeNull();
+  });
+
+  it("respects the regimen gate (everyN)", () => {
+    const med = makeMedication({
+      id: "m1",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      startDate: "2026-07-22",
+      regimen: JSON.stringify({ type: "everyN", n: 7 }),
+    });
+    const daily = makeSchedule({ medicationId: "m1", days: [] });
+    // Anchor 07-22 → next active day after today is 07-29.
+    expect(nextDueDate(med, [daily], NOW)).toEqual({ date: "2026-07-29", inDays: 7 });
+  });
+});

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -16,6 +16,9 @@ import { EmptyState } from "../../components/EmptyState";
 import { CheckinModal } from "../../components/CheckinModal";
 import { AppointmentMiniCard } from "../../components/AppointmentMiniCard";
 import { ProfileChip } from "../../components/ProfileChip";
+import { SitePickerModal } from "../../components/SitePickerModal";
+import { suggestNextSite, type InjectionSite } from "../../src/services/injectionSites";
+import { setDoseInjectionSite } from "../../src/db/database";
 import { CopilotStep, walkthroughable, useCopilot } from "react-native-copilot";
 import { TodayDose, SkipReason } from "../../src/types";
 import { CATEGORY_CONFIG, getColorConfig, formatTimeForDisplay, getLocalizedDosage } from "../../src/utils";
@@ -32,6 +35,7 @@ export default function HomeScreen() {
   const { showToast } = useToast();
   const loadTodayLogs = useAppStore((s) => s.loadTodayLogs);
   const markDose = useAppStore((s) => s.markDose);
+  const getHistoryLogs = useAppStore((s) => s.getHistoryLogs);
   const snoozeDose = useAppStore((s) => s.snoozeDose);
   const rescheduleOnce = useAppStore((s) => s.rescheduleOnce);
   const revertDose = useAppStore((s) => s.revertDose);
@@ -46,6 +50,10 @@ export default function HomeScreen() {
   const setSelectedAppointmentId = useAppStore((s) => s.setSelectedAppointmentId);
   const [refreshing, setRefreshing] = useState(false);
   const [rescheduleTarget, setRescheduleTarget] = useState<TodayDose | null>(null);
+  // Injection-site picker (F3): opened after taking an injectable dose or
+  // from the site chip on a taken dose.
+  const [siteDose, setSiteDose] = useState<TodayDose | null>(null);
+  const [siteSuggestion, setSiteSuggestion] = useState<InjectionSite | null>(null);
 
   const reschedulePan = useRef(
     PanResponder.create({
@@ -176,6 +184,29 @@ export default function HomeScreen() {
   const handleMarkDose = (dose: TodayDose, status: "taken" | "skipped", skipReason?: SkipReason) => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     markDose(dose, status, undefined, skipReason);
+    if (status === "taken" && dose.medication.isInjectable) openSitePicker(dose);
+  };
+
+  const openSitePicker = async (dose: TodayDose) => {
+    try {
+      const to = format(new Date(), "yyyy-MM-dd");
+      const from = format(new Date(Date.now() - 90 * 86_400_000), "yyyy-MM-dd");
+      const logs = (await getHistoryLogs(from, to)).filter(
+        (l) => l.medicationId === dose.medication.id
+      );
+      setSiteSuggestion(suggestNextSite(logs));
+    } catch {
+      setSiteSuggestion(null);
+    }
+    setSiteDose(dose);
+  };
+
+  const handlePickSite = async (site: InjectionSite) => {
+    const dose = siteDose;
+    setSiteDose(null);
+    if (!dose) return;
+    await setDoseInjectionSite(dose.schedule.id, dose.scheduledDate, site);
+    await loadTodayLogs();
   };
 
   const handleSnooze = (dose: TodayDose, minutes?: number) => {
@@ -432,6 +463,7 @@ export default function HomeScreen() {
                     onSnooze={(minutes) => handleSnooze(dose, minutes)}
                     onReschedule={() => openReschedule(dose)}
                     onRevert={dose.snoozedUntil ? () => handleRevertSnooze(dose) : undefined}
+                    onSetSite={() => openSitePicker(dose)}
                   />
                 ))}
               </>
@@ -480,6 +512,7 @@ export default function HomeScreen() {
                     onSnooze={(minutes) => handleSnooze(dose, minutes)}
                     onRevert={() => handleRevert(dose)}
                     onUpdateNote={(note) => handleUpdateNote(dose, note)}
+                    onSetSite={() => openSitePicker(dose)}
                   />
                 ))}
               </>
@@ -628,6 +661,14 @@ export default function HomeScreen() {
       <CheckinModal
         visible={checkinVisible}
         onClose={() => setCheckinVisible(false)}
+      />
+      {/* Injection-site picker (F3) */}
+      <SitePickerModal
+        visible={siteDose !== null}
+        suggested={siteSuggestion}
+        current={siteDose?.injectionSite}
+        onPick={handlePickSite}
+        onClose={() => setSiteDose(null)}
       />
     </SafeAreaView>
   );

--- a/app/medication/[id].tsx
+++ b/app/medication/[id].tsx
@@ -104,6 +104,7 @@ export default function EditMedicationScreen() {
     prnMinIntervalMinutes: medication.prnMinIntervalMinutes,
     rxcui: medication.rxcui,
     regimen: medication.regimen,
+    isInjectable: medication.isInjectable,
     schedules: schedules.map((s) => ({
       id: s.id,
       time: s.time,
@@ -135,6 +136,7 @@ export default function EditMedicationScreen() {
           prnMinIntervalMinutes: values.prnMinIntervalMinutes,
           rxcui: values.rxcui,
           regimen: values.regimen,
+          isInjectable: values.isInjectable,
         },
         // Pass each schedule's id through so unchanged schedules keep their
         // identity (and their dose_logs) instead of being deleted + recreated

--- a/app/medication/new.tsx
+++ b/app/medication/new.tsx
@@ -36,6 +36,7 @@ export default function NewMedicationScreen() {
           prnMinIntervalMinutes: values.prnMinIntervalMinutes,
           rxcui: values.rxcui,
           regimen: values.regimen,
+          isInjectable: values.isInjectable,
         },
         values.schedules.map((s) => ({ time: s.time, days: s.days }))
       );

--- a/components/DoseCard.tsx
+++ b/components/DoseCard.tsx
@@ -20,6 +20,8 @@ import { useAppTheme } from "../src/hooks/useAppTheme";
 import { AppPressable } from "./AppPressable";
 
 interface DoseCardProps {
+  /** Opens the injection-site picker (F3, injectables — taken doses only). */
+  onSetSite?: () => void;
   dose: TodayDose;
   onTake: () => void;
   onSkip: (reason?: SkipReason) => void;
@@ -82,7 +84,7 @@ const STATUS_ICONS = {
   missed:  "alert-circle-outline" as const,
 };
 
-export function DoseCard({ dose, onTake, onSkip, onSnooze, onRevert, onReschedule, onUpdateNote }: DoseCardProps) {
+export function DoseCard({ dose, onTake, onSkip, onSnooze, onRevert, onReschedule, onUpdateNote, onSetSite }: DoseCardProps) {
   const { t } = useTranslation();
   const theme = useAppTheme();
   // Senior / low-vision mode (F1): larger type + taller touch targets.
@@ -427,6 +429,21 @@ export function DoseCard({ dose, onTake, onSkip, onSnooze, onRevert, onReschedul
           <Ionicons name={dose.notes ? "chatbubble-outline" : "add-circle-outline"} size={16} color={theme.secondaryText} />
           <Text className="text-sm" style={{ color: theme.secondaryText }}>
             {dose.notes ? dose.notes : t('doseCard.addNote')}
+          </Text>
+        </AppPressable>
+      )}
+
+      {/* Injection-site chip (F3, taken injectable doses only) */}
+      {dose.status === "taken" && dose.medication.isInjectable && onSetSite && (
+        <AppPressable
+          accessibilityRole="button"
+          accessibilityLabel={t('sites.title')}
+          onPress={onSetSite}
+          className="flex-row items-center gap-1.5 ml-12 py-1 min-h-[44px]"
+        >
+          <Ionicons name="locate-outline" size={16} color={theme.secondaryText} />
+          <Text className="text-sm" style={{ color: theme.secondaryText }}>
+            {dose.injectionSite ? t(`sites.${dose.injectionSite}` as never) : t('sites.record')}
           </Text>
         </AppPressable>
       )}

--- a/components/MedicationCard.tsx
+++ b/components/MedicationCard.tsx
@@ -1,4 +1,5 @@
 ﻿import { View, Text, TouchableOpacity, Switch, Image } from "react-native";
+import { nextDueDate } from "../src/services/injectionSites";
 import { Ionicons } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
 import { Medication, Schedule, DoseLog } from "../src/types";
@@ -193,6 +194,22 @@ export function MedicationCard({
                 return days != null ? ` · ${t('stock.daysLeft', { count: days })}` : "";
               })()}
               {isLow ? ` · ${t('stock.low')}` : ""}
+            </Text>
+          </View>
+        );
+      })()}
+
+      {/* Weekly-injectable countdown (F3): next application date */}
+      {medication.isInjectable && medication.isActive && (() => {
+        const next = nextDueDate(medication, schedules, new Date());
+        if (!next) return null;
+        return (
+          <View className="flex-row items-center gap-1.5 mt-2">
+            <Ionicons name="timer-outline" size={14} color={theme.primary} />
+            <Text className="text-xs font-semibold" style={{ color: theme.primary }}>
+              {next.inDays === 1
+                ? t('sites.nextDoseTomorrow')
+                : t('sites.nextDoseInDays', { count: next.inDays })}
             </Text>
           </View>
         );

--- a/components/MedicationForm.tsx
+++ b/components/MedicationForm.tsx
@@ -7,6 +7,7 @@ import {
   Platform,
   Image,
   FlatList,
+  Switch,
   useWindowDimensions,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -266,6 +267,8 @@ export interface MedicationFormValues {
   rxcui?: string;
   /** Complex regimen JSON (F3) — see services/regimen.ts. */
   regimen?: string;
+  /** Injectable med (F3): site rotation + weekly countdown. */
+  isInjectable?: boolean;
 }
 
 interface MedicationFormProps {
@@ -377,6 +380,7 @@ export function MedicationForm({
           ? String(Math.round((initialValues.prnMinIntervalMinutes / 60) * 100) / 100)
           : "",
       rxcui: initialValues?.rxcui,
+      isInjectable: initialValues?.isInjectable ?? false,
       regimenType: initialRegimen?.type ?? "none",
       regimenNStr: initialRegimen?.type === "everyN" ? String(initialRegimen.n) : "",
       regimenOnStr: initialRegimen?.type === "cycle" ? String(initialRegimen.on) : "",
@@ -483,6 +487,7 @@ export function MedicationForm({
           : undefined,
       rxcui: data.rxcui,
       regimen: buildRegimenFromForm(data),
+      isInjectable: data.isInjectable,
     });
   };
 
@@ -1247,6 +1252,27 @@ export function MedicationForm({
                 </View>
               </View>
             )}
+            {/* Injectable (F3): site rotation + weekly countdown, opt-in */}
+            <View className="flex-row items-center gap-3 py-1">
+              <Ionicons name="fitness-outline" size={18} color={theme.primary} />
+              <View className="flex-1">
+                <Text className="text-sm font-semibold text-text">{t('form.fieldInjectable')}</Text>
+                <Text className="text-xs text-muted mt-0.5">{t('form.fieldInjectableHint')}</Text>
+              </View>
+              <Controller
+                control={control}
+                name="isInjectable"
+                render={({ field: { onChange, value } }) => (
+                  <Switch
+                    value={value}
+                    onValueChange={(v) => { Haptics.selectionAsync(); onChange(v); }}
+                    trackColor={{ false: undefined, true: theme.primary }}
+                    accessibilityLabel={t('form.fieldInjectable')}
+                  />
+                )}
+              />
+            </View>
+
             {/* Prescription renewal (F1) */}
             <DateRow
               label={t('form.fieldRenewal')}

--- a/components/SitePickerModal.tsx
+++ b/components/SitePickerModal.tsx
@@ -1,0 +1,75 @@
+/**
+ * SitePickerModal (F3 injectables): records where an injection went, with
+ * the least-recently-used site suggested. Optional by design — skipping
+ * never blocks the dose log (we don't fabricate medical data).
+ */
+import { View, Text, TouchableOpacity, Modal } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import * as Haptics from "expo-haptics";
+import { useTranslation } from "../src/i18n";
+import { useAppTheme } from "../src/hooks/useAppTheme";
+import { INJECTION_SITES, InjectionSite } from "../src/services/injectionSites";
+
+interface Props {
+  visible: boolean;
+  suggested: InjectionSite | null;
+  current?: string;
+  onPick: (site: InjectionSite) => void;
+  onClose: () => void;
+}
+
+export function SitePickerModal({ visible, suggested, current, onPick, onClose }: Props) {
+  const { t } = useTranslation();
+  const theme = useAppTheme();
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <TouchableOpacity className="flex-1 bg-black/50 justify-center px-8" activeOpacity={1} onPress={onClose}>
+        <View className="rounded-2xl bg-card p-5">
+          <Text className="text-lg font-bold text-text">{t("sites.title")}</Text>
+          <Text className="text-xs text-muted mt-1 mb-4">{t("sites.subtitle")}</Text>
+
+          <View className="flex-row flex-wrap gap-2">
+            {INJECTION_SITES.map((site) => {
+              const isSuggested = site === suggested;
+              const isCurrent = site === current;
+              return (
+                <TouchableOpacity
+                  key={site}
+                  accessibilityRole="button"
+                  accessibilityLabel={t(`sites.${site}`)}
+                  onPress={() => {
+                    Haptics.selectionAsync();
+                    onPick(site);
+                  }}
+                  className={`rounded-xl px-3 py-2.5 border ${
+                    isCurrent
+                      ? "bg-primary border-primary"
+                      : isSuggested
+                        ? "border-primary bg-blue-50 dark:bg-blue-950/30"
+                        : "bg-card-alt border-border"
+                  }`}
+                  style={{ width: "48%" }}
+                >
+                  <Text className={`text-sm font-semibold ${isCurrent ? "text-white" : "text-text"}`}>
+                    {t(`sites.${site}`)}
+                  </Text>
+                  {isSuggested && !isCurrent && (
+                    <Text className="text-[10px] font-bold mt-0.5" style={{ color: theme.primary }}>
+                      {t("sites.suggested")}
+                    </Text>
+                  )}
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+
+          <TouchableOpacity onPress={onClose} className="self-end mt-4 py-2 px-3 flex-row items-center gap-1">
+            <Ionicons name="close" size={14} color={theme.muted} />
+            <Text className="text-muted font-semibold text-sm">{t("sites.skip")}</Text>
+          </TouchableOpacity>
+        </View>
+      </TouchableOpacity>
+    </Modal>
+  );
+}

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -168,6 +168,7 @@ function toMedication(row: typeof schema.medications.$inferSelect): Medication {
     rxcui: row.rxcui ?? undefined,
     profileId: row.profileId,
     regimen: row.regimen ?? undefined,
+    isInjectable: row.isInjectable,
   };
 }
 
@@ -200,6 +201,7 @@ function toDoseLog(row: typeof schema.doseLogs.$inferSelect): DoseLog {
     createdAt: row.createdAt,
     notes: row.notes ?? undefined,
     skipReason: (row.skipReason as SkipReason) ?? undefined,
+    injectionSite: row.injectionSite ?? undefined,
   };
 }
 
@@ -301,7 +303,8 @@ export async function initDatabase(): Promise<void> {
       prn_min_interval_minutes INTEGER,
       rxcui         TEXT,
       profile_id    TEXT NOT NULL DEFAULT 'default',
-      regimen       TEXT
+      regimen       TEXT,
+      is_injectable INTEGER NOT NULL DEFAULT 0
     );
 
     CREATE TABLE IF NOT EXISTS schedules (
@@ -322,7 +325,8 @@ export async function initDatabase(): Promise<void> {
       taken_at        TEXT,
       created_at      TEXT NOT NULL,
       notes           TEXT,
-      skip_reason     TEXT
+      skip_reason     TEXT,
+      injection_site  TEXT
     );
 
     CREATE UNIQUE INDEX IF NOT EXISTS idx_dose_unique
@@ -569,6 +573,17 @@ export async function initDatabase(): Promise<void> {
     try { expoDb.execSync("ALTER TABLE medications ADD COLUMN regimen TEXT"); } catch { /* exists */ }
     expoDb.execSync("PRAGMA user_version = 15");
   }
+
+  if (user_version < 16) {
+    // F3: injectables — site rotation on dose logs, opt-in per medication.
+    for (const stmt of [
+      "ALTER TABLE medications ADD COLUMN is_injectable INTEGER NOT NULL DEFAULT 0",
+      "ALTER TABLE dose_logs ADD COLUMN injection_site TEXT",
+    ]) {
+      try { expoDb.execSync(stmt); } catch { /* exists */ }
+    }
+    expoDb.execSync("PRAGMA user_version = 16");
+  }
 }
 
 
@@ -655,6 +670,7 @@ export async function insertMedication(med: Medication): Promise<void> {
     rxcui: med.rxcui ?? null,
     profileId: med.profileId ?? getActiveProfileId(),
     regimen: med.regimen ?? null,
+    isInjectable: med.isInjectable ?? false,
   }).run();
 }
 
@@ -680,6 +696,7 @@ export async function updateMedication(med: Medication): Promise<void> {
     prnMinIntervalMinutes: med.prnMinIntervalMinutes ?? null,
     rxcui: med.rxcui ?? null,
     regimen: med.regimen ?? null,
+    isInjectable: med.isInjectable ?? false,
   }).where(eq(schema.medications.id, med.id)).run();
 }
 
@@ -979,6 +996,17 @@ export async function deleteAppointmentDocument(id: string): Promise<void> {
 export async function updateMedicationStock(id: string, newQuantity: number): Promise<void> {
   db.update(schema.medications).set({ stockQuantity: newQuantity })
     .where(eq(schema.medications.id, id)).run();
+}
+
+/** Records the injection site on an already-logged dose (F3 injectables). */
+export async function setDoseInjectionSite(
+  scheduleId: string,
+  scheduledDate: string,
+  site: string
+): Promise<void> {
+  db.update(schema.doseLogs).set({ injectionSite: site })
+    .where(and(eq(schema.doseLogs.scheduleId, scheduleId), eq(schema.doseLogs.scheduledDate, scheduledDate)))
+    .run();
 }
 
 export async function updateDoseLogNotes(

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -37,6 +37,7 @@ export const medications = sqliteTable("medications", {
   rxcui: text("rxcui"),
   profileId: text("profile_id").notNull().default("default"),
   regimen: text("regimen"),
+  isInjectable: integer("is_injectable", { mode: "boolean" }).notNull().default(false),
 });
 
 // ─── Schedules ─────────────────────────────────────────────────────────────
@@ -69,6 +70,7 @@ export const doseLogs = sqliteTable(
     createdAt: text("created_at").notNull(),
     notes: text("notes"),
     skipReason: text("skip_reason"),
+    injectionSite: text("injection_site"),
   },
   (t) => [
     uniqueIndex("idx_dose_unique").on(t.scheduleId, t.scheduledDate),

--- a/src/hooks/useTodaySchedule.ts
+++ b/src/hooks/useTodaySchedule.ts
@@ -61,6 +61,7 @@ export function useTodaySchedule(dateStr?: string): TodayDose[] {
         scheduledTime: schedule.time,
         status,
         takenAt: log?.takenAt,
+        injectionSite: log?.injectionSite,
         notes: log?.notes,
         skipReason: log?.skipReason,
         snoozedUntil: isToday ? snoozedTimes[`${schedule.id}-${targetDate}`] : undefined,

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -195,6 +195,8 @@ const en: TranslationShape = {
     fieldRenewal: "Prescription renewal (optional)",
     fieldRenewalHint: "We'll remind you 7 days before and on the day itself.",
     drugDbAttribution: "Suggestions: RxTerms (U.S. National Library of Medicine)",
+    fieldInjectable: "Injectable",
+    fieldInjectableHint: "Enables site rotation and the countdown to the next application.",
     sectionRegimen: "Advanced regimen (optional)",
     regimen_none: "Normal",
     regimen_everyN: "Every N days",
@@ -507,6 +509,21 @@ const en: TranslationShape = {
   },
 
   // ─── PDF report ─────────────────────────────────────────────────────────
+  sites: {
+    title: "Where did you inject?",
+    subtitle: "Recording the site helps you rotate and avoid irritation. Optional.",
+    suggested: "suggested",
+    record: "Record injection site",
+    skip: "Skip",
+    abdomen_l: "Left abdomen",
+    abdomen_r: "Right abdomen",
+    thigh_l: "Left thigh",
+    thigh_r: "Right thigh",
+    arm_l: "Left arm",
+    arm_r: "Right arm",
+    nextDoseTomorrow: "Next dose: tomorrow",
+    nextDoseInDays: "Next dose in {{count}} days",
+  },
   profiles: {
     sectionTitle: "Profiles",
     me: "Me",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -193,6 +193,8 @@ const es = {
     fieldRenewal: "Renovación de receta (opcional)",
     fieldRenewalHint: "Te avisamos 7 días antes y el mismo día.",
     drugDbAttribution: "Sugerencias: RxTerms (U.S. National Library of Medicine)",
+    fieldInjectable: "Es inyectable",
+    fieldInjectableHint: "Activa la rotación de sitio y el conteo hasta la próxima aplicación.",
     sectionRegimen: "Régimen avanzado (opcional)",
     regimen_none: "Normal",
     regimen_everyN: "Cada N días",
@@ -505,6 +507,21 @@ const es = {
   },
 
   // ─── Informe PDF ────────────────────────────────────────────────────────
+  sites: {
+    title: "¿Dónde te la aplicaste?",
+    subtitle: "Registrar el sitio ayuda a rotar y evitar irritación. Es opcional.",
+    suggested: "sugerido",
+    record: "Registrar sitio de aplicación",
+    skip: "Omitir",
+    abdomen_l: "Abdomen izquierdo",
+    abdomen_r: "Abdomen derecho",
+    thigh_l: "Muslo izquierdo",
+    thigh_r: "Muslo derecho",
+    arm_l: "Brazo izquierdo",
+    arm_r: "Brazo derecho",
+    nextDoseTomorrow: "Próxima aplicación: mañana",
+    nextDoseInDays: "Próxima aplicación en {{count}} días",
+  },
   profiles: {
     sectionTitle: "Perfiles",
     me: "Yo",

--- a/src/schemas/medication.ts
+++ b/src/schemas/medication.ts
@@ -32,6 +32,8 @@ export const medicationFormSchema = z
     regimenOnStr: z.string().optional().default(""),
     regimenOffStr: z.string().optional().default(""),
     taperSteps: z.array(z.object({ daysStr: z.string(), amountStr: z.string() })).default([]),
+    // Injectable flag (F3): enables site rotation + weekly countdown.
+    isInjectable: z.boolean().default(false),
   })
   .superRefine((data, ctx) => {
     // Validate dosage is a positive number

--- a/src/services/backup.ts
+++ b/src/services/backup.ts
@@ -49,6 +49,7 @@ const medicationSchema = z.object({
   rxcui: z.string().optional(),
   profileId: z.string().optional(),
   regimen: z.string().optional(),
+  isInjectable: z.boolean().optional(),
 });
 
 const profileSchema = z.object({
@@ -77,6 +78,7 @@ const doseLogSchema = z.object({
   createdAt: z.string(),
   notes: z.string().optional(),
   skipReason: z.enum(["forgot", "side_effect", "no_stock", "other"]).optional(),
+  injectionSite: z.string().optional(),
 });
 
 const appointmentSchema = z.object({

--- a/src/services/injectionSites.ts
+++ b/src/services/injectionSites.ts
@@ -1,0 +1,69 @@
+/**
+ * Injection-site rotation (F3 — GLP-1 / weekly injectables).
+ *
+ * Standard pen sites: abdomen (L/R), thigh (L/R), upper arm (L/R). The
+ * suggestion is the least-recently-used site so consecutive doses naturally
+ * rotate — the guidance every GLP-1 leaflet gives. Recording a site is
+ * always optional: we never fabricate one the user didn't confirm.
+ */
+import { DoseLog, Medication, Schedule } from "../types";
+import { isScheduleActiveOnDate } from "../utils";
+
+export const INJECTION_SITES = [
+  "abdomen_l",
+  "abdomen_r",
+  "thigh_l",
+  "thigh_r",
+  "arm_l",
+  "arm_r",
+] as const;
+
+export type InjectionSite = (typeof INJECTION_SITES)[number];
+
+/**
+ * Least-recently-used site given the med's past logs (most recent first or
+ * not — order is derived from scheduledDate). Sites never used win first,
+ * in list order.
+ */
+export function suggestNextSite(logs: DoseLog[]): InjectionSite {
+  const lastUsed = new Map<string, string>();
+  for (const log of logs) {
+    if (!log.injectionSite) continue;
+    const prev = lastUsed.get(log.injectionSite);
+    if (!prev || log.scheduledDate > prev) lastUsed.set(log.injectionSite, log.scheduledDate);
+  }
+  let best: InjectionSite = INJECTION_SITES[0];
+  let bestDate = "9999-99-99";
+  for (const site of INJECTION_SITES) {
+    const used = lastUsed.get(site);
+    if (!used) return site; // never used → immediate winner
+    if (used < bestDate) {
+      best = site;
+      bestDate = used;
+    }
+  }
+  return best;
+}
+
+/**
+ * Next date (YYYY-MM-DD, local) the medication is due, scanning up to
+ * `horizon` days from tomorrow. Powers the weekly countdown on the med list.
+ */
+export function nextDueDate(
+  med: Medication,
+  schedules: Schedule[],
+  from: Date,
+  horizon = 35
+): { date: string; inDays: number } | null {
+  const active = schedules.filter((s) => s.medicationId === med.id && s.isActive);
+  if (active.length === 0) return null;
+  for (let i = 1; i <= horizon; i++) {
+    const d = new Date(from.getFullYear(), from.getMonth(), from.getDate() + i, 12);
+    if (active.some((s) => isScheduleActiveOnDate(s, d, med))) {
+      const m = String(d.getMonth() + 1).padStart(2, "0");
+      const day = String(d.getDate()).padStart(2, "0");
+      return { date: `${d.getFullYear()}-${m}-${day}`, inDays: i };
+    }
+  }
+  return null;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -80,6 +80,8 @@ export interface Medication {
   profileId?: string;
   /** Complex regimen JSON (F3): everyN / cycle / taper — see services/regimen.ts. */
   regimen?: string;
+  /** Injectable med (F3, GLP-1 wave): enables site rotation + weekly countdown. */
+  isInjectable?: boolean;
 }
 
 // ─── Schedule ──────────────────────────────────────────────────────────────
@@ -121,6 +123,8 @@ export interface DoseLog {
   notes?: string;
   /** Reason the user gave for skipping this dose (only set when status = 'skipped'). */
   skipReason?: SkipReason;
+  /** Injection site key (F3) — see services/injectionSites.ts; injectables only. */
+  injectionSite?: string;
 }
 
 // ─── Appointment ──────────────────────────────────────────────────────────
@@ -229,6 +233,8 @@ export interface TodayDose {
   scheduledDate: string;
   scheduledTime: string;
   status: TodayDoseStatus;
+  /** Injection site recorded on the log (F3 injectables). */
+  injectionSite?: string;
   takenAt?: string;
   /** Free-text note attached to the dose log (if any). */
   notes?: string;


### PR DESCRIPTION
## Qué hace

**Inyectables / GLP-1** (Fase 3): rotación de sitio + countdown semanal, **opt-in por medicamento** — quien toma pastillas no ve nada nuevo. La titulación ya la cubre el régimen descendente (#95).

- **Rotación de sitio**: al marcar tomada una dosis inyectable en Hoy se abre un selector con los 6 sitios estándar de pluma (abdomen/muslo/brazo, izq+der) y el **menos usado recientemente** sugerido. Registrar es siempre opcional — nunca inventamos un dato médico. Un chip en la dosis tomada permite cargarlo después (cubre las tomas desde la alarma).
- **Countdown semanal**: la tarjeta del medicamento muestra "Próxima aplicación en N días", consciente del régimen (usa el mismo choke point de scheduling).

## Implementación

- Migración v16: `medications.is_injectable` + `dose_logs.injection_site`. Backup round-trip de ambos.
- `src/services/injectionSites.ts`: sugerencia LRU (sitios nunca usados primero) + `nextDueDate`. Switch "Es inyectable" en Extras del formulario. i18n ES/EN.

## Validación

- Jest **272/272** (7 tests nuevos), eslint limpio, tsc solo baseline. Sin cambios nativos.
- Pendiente en dispositivo: flujo tomar→selector de sitio y countdown con el próximo build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
