### PR TITLE
feat(archive): archivar medicamentos en vez de borrar (F3)

### DIFF
--- a/__tests__/store/medicationsSlice.test.ts
+++ b/__tests__/store/medicationsSlice.test.ts
@@ -322,6 +322,50 @@ describe("logPRNDose", () => {
   });
 });
 
+// ─── archiveMedication (F3) ────────────────────────────────────────────────
+
+describe("archiveMedication", () => {
+  it("cancels alarms + renewals BEFORE archiving and records reason+date", async () => {
+    const med = makeMedication({ id: "med-1" });
+    const sch = makeSchedule({ id: "sch-1", medicationId: "med-1" });
+    jest.mocked(db.getSchedulesByMedication).mockResolvedValue([sch]);
+
+    const store = makeTestStore({ medications: [med] });
+    await store.getState().archiveMedication("med-1", "side_effects");
+
+    expect(jest.mocked(notifs.cancelScheduleNotifications)).toHaveBeenCalledWith("sch-1");
+    expect(jest.mocked(notifs.cancelRenewalReminders)).toHaveBeenCalledWith(med);
+    expect(jest.mocked(db.updateMedication)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "med-1",
+        isActive: false,
+        archiveReason: "side_effects",
+        archivedAt: expect.any(String),
+      })
+    );
+  });
+
+  it("unarchive restores and reschedules", async () => {
+    const med = makeMedication({
+      id: "med-1",
+      isActive: false,
+      archivedAt: "2026-07-01T00:00:00.000Z",
+      archiveReason: "finished",
+    });
+    const sch = makeSchedule({ id: "sch-1", medicationId: "med-1" });
+    jest.mocked(db.getSchedulesByMedication).mockResolvedValue([sch]);
+
+    const store = makeTestStore({ medications: [med] });
+    await store.getState().unarchiveMedication("med-1");
+
+    expect(jest.mocked(db.updateMedication)).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "med-1", isActive: true, archivedAt: undefined, archiveReason: undefined })
+    );
+    // Rescheduling goes through _scheduleNotificationsForSchedule → scheduleDoseChain.
+    expect(jest.mocked(notifs.scheduleDoseChain)).toHaveBeenCalled();
+  });
+});
+
 // ─── getHistoryLogs ────────────────────────────────────────────────────────
 
 describe("getHistoryLogs", () => {

--- a/app/(tabs)/medications.tsx
+++ b/app/(tabs)/medications.tsx
@@ -9,10 +9,12 @@ import { EmptyState } from "../../components/EmptyState";
 import { useState } from "react";
 import { useTranslation } from "../../src/i18n";
 import { prnWarningMessage } from "../../src/services/prnLimits";
+import { useAppTheme } from "../../src/hooks/useAppTheme";
 
 export default function MedicationsScreen() {
   const router = useRouter();
   const { t } = useTranslation();
+  const theme = useAppTheme();
   const medications = useAppStore((s) => s.medications);
   const schedules = useAppStore((s) => s.schedules);
   const todayLogs = useAppStore((s) => s.todayLogs);
@@ -31,6 +33,25 @@ export default function MedicationsScreen() {
 
   const handleToggleActive = (id: string, val: boolean) => {
     toggleActive(id, val);
+  };
+
+  // Archive instead of delete (F3): reason picker via Alert buttons.
+  const archiveMedication = useAppStore((st) => st.archiveMedication);
+  const unarchiveMedication = useAppStore((st) => st.unarchiveMedication);
+
+  const handleArchive = (id: string, name: string) => {
+    const reasons = ["finished", "doctor", "side_effects", "other"] as const;
+    Alert.alert(
+      t("archive.confirmTitle", { name }),
+      t("archive.confirmMsg"),
+      [
+        ...reasons.map((r) => ({
+          text: t(`archive.reason_${r}`),
+          onPress: () => archiveMedication(id, r),
+        })),
+        { text: t("common.cancel"), style: "cancel" as const },
+      ]
+    );
   };
 
   const handleDelete = (id: string, name: string) => {
@@ -105,7 +126,8 @@ export default function MedicationsScreen() {
   };
 
   const active = medications.filter((m) => m.isActive);
-  const inactive = medications.filter((m) => !m.isActive);
+  const inactive = medications.filter((m) => !m.isActive && !m.archivedAt);
+  const archived = medications.filter((m) => !!m.archivedAt);
 
   return (
     <SafeAreaView className="flex-1 bg-background">
@@ -155,6 +177,7 @@ export default function MedicationsScreen() {
                     onDelete={() => handleDelete(med.id, med.name)}
                     onToggleActive={(val) => handleToggleActive(med.id, val)}
                     onLogPRN={() => handleLogPRN(med.id, med.name)}
+                    onArchive={() => handleArchive(med.id, med.name)}
                   />
                 ))}
               </>
@@ -179,7 +202,50 @@ export default function MedicationsScreen() {
                     onEdit={() => router.push(`/medication/${med.id}`)}
                     onDelete={() => handleDelete(med.id, med.name)}
                     onToggleActive={(val) => handleToggleActive(med.id, val)}
+                    onArchive={() => handleArchive(med.id, med.name)}
                   />
+                ))}
+              </>
+            )}
+
+            {/* Archived (F3): history kept, compact rows, unarchive action */}
+            {archived.length > 0 && (
+              <>
+                <View className="h-px bg-border my-4" />
+                <Text className="text-xs font-bold text-muted uppercase tracking-widest mb-2">
+                  {t("archive.section")}
+                </Text>
+                {archived.map((med) => (
+                  <View
+                    key={med.id}
+                    className="flex-row items-center gap-3 bg-card border border-border rounded-2xl px-4 py-3 mb-2 opacity-80"
+                  >
+                    <Ionicons name="archive-outline" size={18} color={theme.muted} />
+                    <View className="flex-1">
+                      <Text className="text-[15px] font-semibold text-text" numberOfLines={1}>
+                        {med.name}
+                      </Text>
+                      <Text className="text-[11px] text-muted mt-0.5">
+                        {t(`archive.reason_${med.archiveReason ?? "other"}` as never)} · {med.archivedAt?.slice(0, 10)}
+                      </Text>
+                    </View>
+                    <TouchableOpacity
+                      accessibilityRole="button"
+                      accessibilityLabel={t("archive.restore")}
+                      onPress={() => unarchiveMedication(med.id)}
+                      className="p-2"
+                    >
+                      <Ionicons name="refresh-outline" size={18} color={theme.primary} />
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      accessibilityRole="button"
+                      accessibilityLabel={t("common.delete")}
+                      onPress={() => handleDelete(med.id, med.name)}
+                      className="p-2"
+                    >
+                      <Ionicons name="trash-outline" size={18} color={theme.danger} />
+                    </TouchableOpacity>
+                  </View>
                 ))}
               </>
             )}

--- a/components/MedicationCard.tsx
+++ b/components/MedicationCard.tsx
@@ -13,6 +13,8 @@ interface MedicationCardProps {
   schedules: Schedule[];
   onEdit: () => void;
   onDelete: () => void;
+  /** Retire keeping history (F3) — offered alongside delete. */
+  onArchive?: () => void;
   onToggleActive: (isActive: boolean) => void;
   /** Today's dose logs — used to compute the "next dose" indicator. */
   todayLogs?: DoseLog[];
@@ -26,6 +28,7 @@ export function MedicationCard({
   schedules,
   onEdit,
   onDelete,
+  onArchive,
   onToggleActive,
   todayLogs = [],
   onLogPRN,
@@ -288,6 +291,17 @@ export function MedicationCard({
           <Ionicons name="pencil-outline" size={16} color="#3b82f6" />
           <Text className="text-blue-600 dark:text-blue-400 text-sm font-semibold">{t('common.edit')}</Text>
         </TouchableOpacity>
+        {onArchive && (
+          <TouchableOpacity
+            accessibilityRole="button"
+            accessibilityLabel={`${t('archive.action')} ${medication.name}`}
+            onPress={() => { Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light); onArchive(); }}
+            className="flex-row items-center justify-center gap-1.5 bg-card-alt border border-border rounded-xl px-4 py-3 min-h-[44px] min-w-[44px]"
+          >
+            <Ionicons name="archive-outline" size={16} color={theme.muted} />
+            <Text className="text-sm font-semibold text-muted">{t('archive.action')}</Text>
+          </TouchableOpacity>
+        )}
         <TouchableOpacity
           accessibilityRole="button"
           accessibilityLabel={`${t('common.delete')} ${medication.name}`}

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -170,6 +170,8 @@ function toMedication(row: typeof schema.medications.$inferSelect): Medication {
     profileId: row.profileId,
     regimen: row.regimen ?? undefined,
     isInjectable: row.isInjectable,
+    archivedAt: row.archivedAt ?? undefined,
+    archiveReason: row.archiveReason ?? undefined,
   };
 }
 
@@ -317,7 +319,9 @@ export async function initDatabase(): Promise<void> {
       rxcui         TEXT,
       profile_id    TEXT NOT NULL DEFAULT 'default',
       regimen       TEXT,
-      is_injectable INTEGER NOT NULL DEFAULT 0
+      is_injectable INTEGER NOT NULL DEFAULT 0,
+      archived_at    TEXT,
+      archive_reason TEXT
     );
 
     CREATE TABLE IF NOT EXISTS schedules (
@@ -618,6 +622,17 @@ export async function initDatabase(): Promise<void> {
     }
     expoDb.execSync("PRAGMA user_version = 17");
   }
+
+  if (user_version < 18) {
+    // F3: archive instead of delete — history with a reason and a date.
+    for (const stmt of [
+      "ALTER TABLE medications ADD COLUMN archived_at TEXT",
+      "ALTER TABLE medications ADD COLUMN archive_reason TEXT",
+    ]) {
+      try { expoDb.execSync(stmt); } catch { /* exists */ }
+    }
+    expoDb.execSync("PRAGMA user_version = 18");
+  }
 }
 
 
@@ -764,6 +779,8 @@ export async function insertMedication(med: Medication): Promise<void> {
     profileId: med.profileId ?? getActiveProfileId(),
     regimen: med.regimen ?? null,
     isInjectable: med.isInjectable ?? false,
+    archivedAt: med.archivedAt ?? null,
+    archiveReason: med.archiveReason ?? null,
   }).run();
 }
 
@@ -790,6 +807,8 @@ export async function updateMedication(med: Medication): Promise<void> {
     rxcui: med.rxcui ?? null,
     regimen: med.regimen ?? null,
     isInjectable: med.isInjectable ?? false,
+    archivedAt: med.archivedAt ?? null,
+    archiveReason: med.archiveReason ?? null,
   }).where(eq(schema.medications.id, med.id)).run();
 }
 

--- a/src/db/database.web.ts
+++ b/src/db/database.web.ts
@@ -286,3 +286,24 @@ export async function getAppointments(): Promise<Appointment[]> {
 export async function getActiveAppointments(): Promise<Appointment[]> {
   return [];
 }
+
+/** Stock counter update (web parity with database.ts). */
+export async function updateMedicationStock(id: string, newQuantity: number): Promise<void> {
+  const meds = load<Medication>(KEYS.medications);
+  save(KEYS.medications, meds.map((m) => (m.id === id ? { ...m, stockQuantity: newQuantity } : m)));
+}
+
+/** Dose-log note update (web parity with database.ts). */
+export async function updateDoseLogNotes(
+  scheduleId: string,
+  scheduledDate: string,
+  notes: string
+): Promise<void> {
+  const logs = load<DoseLog>(KEYS.doseLogs);
+  save(
+    KEYS.doseLogs,
+    logs.map((l) =>
+      l.scheduleId === scheduleId && l.scheduledDate === scheduledDate ? { ...l, notes } : l
+    )
+  );
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -56,6 +56,8 @@ export const medications = sqliteTable("medications", {
   profileId: text("profile_id").notNull().default("default"),
   regimen: text("regimen"),
   isInjectable: integer("is_injectable", { mode: "boolean" }).notNull().default(false),
+  archivedAt: text("archived_at"),
+  archiveReason: text("archive_reason"),
 });
 
 // ─── Schedules ─────────────────────────────────────────────────────────────

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -509,6 +509,17 @@ const en: TranslationShape = {
   },
 
   // ─── PDF report ─────────────────────────────────────────────────────────
+  archive: {
+    action: "Archive",
+    section: "Archived",
+    restore: "Restore medication",
+    confirmTitle: "Archive {{name}}",
+    confirmMsg: "Its alarms are cancelled but the history is kept. Why are you stopping it?",
+    reason_finished: "Finished the treatment",
+    reason_doctor: "Doctor's instruction",
+    reason_side_effects: "Side effects",
+    reason_other: "Other reason",
+  },
   allergies: {
     title: "Allergies",
     settingsSubtitle: "For the active profile; we warn if a new medication contains an ingredient you're allergic to",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -507,6 +507,17 @@ const es = {
   },
 
   // ─── Informe PDF ────────────────────────────────────────────────────────
+  archive: {
+    action: "Archivar",
+    section: "Archivados",
+    restore: "Restaurar medicamento",
+    confirmTitle: "Archivar {{name}}",
+    confirmMsg: "Se cancelan sus alarmas pero el historial se conserva. ¿Por qué lo dejás de tomar?",
+    reason_finished: "Terminé el tratamiento",
+    reason_doctor: "Indicación médica",
+    reason_side_effects: "Efectos adversos",
+    reason_other: "Otro motivo",
+  },
   allergies: {
     title: "Alergias",
     settingsSubtitle: "Del perfil activo; avisamos si un medicamento nuevo contiene un ingrediente al que sos alérgico",

--- a/src/services/backup.ts
+++ b/src/services/backup.ts
@@ -52,6 +52,8 @@ const medicationSchema = z.object({
   profileId: z.string().optional(),
   regimen: z.string().optional(),
   isInjectable: z.boolean().optional(),
+  archivedAt: z.string().optional(),
+  archiveReason: z.string().optional(),
 });
 
 const profileSchema = z.object({

--- a/src/store/slices/medications.ts
+++ b/src/store/slices/medications.ts
@@ -171,6 +171,35 @@ export const createMedicationsSlice: StateCreator<AppState, [], [], MedicationsS
     set({ medications: allMeds });
   },
 
+  // ── Archive / unarchive (F3): retire without losing history ────────────
+
+  async archiveMedication(id, reason) {
+    const med = get().medications.find((m) => m.id === id);
+    if (!med) return;
+    // Silence everything first — an archived med must never ring.
+    const schedules = await getSchedulesByMedication(id);
+    await Promise.all(schedules.map((s) => cancelScheduleNotifications(s.id)));
+    await cancelRenewalReminders(med);
+    await updateMedication({
+      ...med,
+      isActive: false,
+      archivedAt: new Date().toISOString(),
+      archiveReason: reason,
+      renewalNotifIds: undefined,
+    });
+    set({ medications: await getActiveMedications() });
+  },
+
+  async unarchiveMedication(id) {
+    const med = get().medications.find((m) => m.id === id);
+    if (!med) return;
+    const restored = { ...med, isActive: true, archivedAt: undefined, archiveReason: undefined };
+    await updateMedication(restored);
+    const schedules = await getSchedulesByMedication(id);
+    await Promise.all(schedules.map((s) => _scheduleNotificationsForSchedule(restored, s)));
+    set({ medications: await getActiveMedications() });
+  },
+
   // ── Mark dose (taken / skipped) ────────────────────────────────────────
 
   async markDose(dose, status, notes, skipReason) {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -24,6 +24,9 @@ export interface MedicationsSlice {
 
   deleteMedication: (id: string) => Promise<void>;
   toggleMedicationActive: (id: string, isActive: boolean) => Promise<void>;
+  /** Retire a med keeping its history (F3): cancels alarms, records reason+date. */
+  archiveMedication: (id: string, reason: string) => Promise<void>;
+  unarchiveMedication: (id: string) => Promise<void>;
 
   markDose: (
     dose: TodayDose,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -95,6 +95,10 @@ export interface Medication {
   regimen?: string;
   /** Injectable med (F3, GLP-1 wave): enables site rotation + weekly countdown. */
   isInjectable?: boolean;
+  /** Archive instead of delete (F3): when set, the med is retired but its history stays. */
+  archivedAt?: string;
+  /** Why it was archived: finished | doctor | side_effects | other. */
+  archiveReason?: string;
 }
 
 // ─── Schedule ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Qué hace

**Archivo de medicamentos** (Fase 3): retirar un medicamento **sin borrar su historial** — pedido recurrente de la categoría. Botón "Archivar" en cada tarjeta con selector de motivo (terminé el tratamiento / indicación médica / efectos adversos / otro).

- Al archivar se cancelan **primero** sus alarmas y recordatorios de renovación (un med archivado no puede sonar jamás — test dedicado), y recién después se persiste `archivedAt` + motivo.
- Sección compacta "Archivados" al pie de la lista: nombre, motivo, fecha, restaurar (reprograma alarmas) y eliminar definitivo.
- El historial de tomas queda intacto; History e Insights lo siguen viendo.
- Migración v18; backup round-trip. De paso, paridad del stub web para 2 exports que faltaban (errores latentes del resolver).

## Validación

Jest **279/279** (2 tests nuevos), eslint limpio, tsc solo baseline. Sin cambios nativos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
