### PR TITLE
feat(timezone): reconstruir recordatorios al cambiar de huso horario (F3)

### DIFF
--- a/__tests__/timezone.test.ts
+++ b/__tests__/timezone.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Timezone-change detection (F3 travel reliability).
+ */
+import { detectTimezoneChange, getDeviceTimezone } from "../src/services/timezone";
+import { storage } from "../src/storage";
+import { STORAGE_KEYS } from "../src/config";
+
+beforeEach(() => {
+  storage.delete(STORAGE_KEYS.LAST_TIMEZONE);
+});
+
+describe("detectTimezoneChange", () => {
+  it("first run persists but never reports a change", () => {
+    const r = detectTimezoneChange("America/Argentina/Buenos_Aires");
+    expect(r.changed).toBe(false);
+    expect(storage.getString(STORAGE_KEYS.LAST_TIMEZONE)).toBe("America/Argentina/Buenos_Aires");
+  });
+
+  it("same zone → no change", () => {
+    detectTimezoneChange("America/Argentina/Buenos_Aires");
+    expect(detectTimezoneChange("America/Argentina/Buenos_Aires").changed).toBe(false);
+  });
+
+  it("different zone → change with from/to, and persists the new zone", () => {
+    detectTimezoneChange("America/Argentina/Buenos_Aires");
+    const r = detectTimezoneChange("Europe/Madrid");
+    expect(r).toEqual({
+      changed: true,
+      from: "America/Argentina/Buenos_Aires",
+      to: "Europe/Madrid",
+    });
+    // Next check from Madrid is stable again.
+    expect(detectTimezoneChange("Europe/Madrid").changed).toBe(false);
+  });
+
+  it("getDeviceTimezone returns something usable", () => {
+    expect(getDeviceTimezone()).toBeTruthy();
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,6 +45,7 @@ export const STORAGE_KEYS = {
   SENIOR_MODE:                "@pilloclock/senior_mode",
   HEALTH_SYNC:                "@pilloclock/health_sync",
   ACTIVE_PROFILE:             "@pilloclock/active_profile",
+  LAST_TIMEZONE:              "@pilloclock/last_timezone",
   RECENT_COLORS:            "custom_colors_recent",
   // Legacy keys kept for migration only (notifications.ts)
   NOTIF_MAP:                "@pilloclock/notif_map",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -511,6 +511,10 @@ const en: TranslationShape = {
   },
 
   // ─── PDF report ─────────────────────────────────────────────────────────
+  timezone: {
+    adjustedTitle: "Timezone change",
+    adjustedBody: "We adjusted your reminders to local time in {{tz}}.",
+  },
   archive: {
     action: "Archive",
     section: "Archived",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -509,6 +509,10 @@ const es = {
   },
 
   // ─── Informe PDF ────────────────────────────────────────────────────────
+  timezone: {
+    adjustedTitle: "Cambio de huso horario",
+    adjustedBody: "Ajustamos tus recordatorios a la hora local de {{tz}}.",
+  },
   archive: {
     action: "Archivar",
     section: "Archivados",

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -10,6 +10,7 @@ import i18n from "../i18n";
 import { STORAGE_KEYS } from "../config";
 import { getDefaultSnoozeMinutes as getSnoozeMin } from "./snoozeSettings";
 import { withEffectiveDose } from "./regimen";
+import { detectTimezoneChange } from "./timezone";
 import { getMedications, getAllActiveSchedules, getDoseLogsByDateRange, getDb, getProfiles } from "../db/database";
 
 // ─── Constants ─────────────────────────────────────────────────────────────
@@ -873,6 +874,30 @@ export async function cleanupExpiredNotifMapEntries(): Promise<void> {
  */
 export async function rescheduleAllNotifications(): Promise<void> {
   if (Platform.OS === "web") return;
+
+  // Timezone travel (F3): queued alarms/notifications are absolute instants
+  // from the zone where they were scheduled. On a zone change, cancel all of
+  // them so the rebuild below lands on the new local wall-clock times.
+  const tz = detectTimezoneChange();
+  if (tz.changed) {
+    try {
+      const allSchedules = await getAllActiveSchedules();
+      for (const s of allSchedules) {
+        await cancelScheduleNotifications(s.id);
+      }
+      await Notifications.scheduleNotificationAsync({
+        content: {
+          title: i18n.t("timezone.adjustedTitle"),
+          body: i18n.t("timezone.adjustedBody", { tz: tz.to }),
+          data: { type: "timezone_adjusted" },
+          ...(Platform.OS === "android" ? { channelId: STOCK_ALERT_CHANNEL_ID } : {}),
+        },
+        trigger: null, // immediate, informational
+      });
+    } catch {
+      // Never let the tz handling break rescheduling itself.
+    }
+  }
 
   // Purge stale entries first so the map doesn't grow indefinitely.
   await cleanupExpiredNotifMapEntries();

--- a/src/services/timezone.ts
+++ b/src/services/timezone.ts
@@ -1,0 +1,42 @@
+/**
+ * Timezone-travel reliability (F3).
+ *
+ * Schedules are wall-clock ("08:00 wherever I am"), but queued Android
+ * alarms and iOS notifications are absolute instants computed in the zone
+ * where they were scheduled. After a timezone change those instants land at
+ * the wrong local time. rescheduleAllNotifications() calls
+ * detectTimezoneChange() on every app foreground: when the zone changed,
+ * everything queued is cancelled and rebuilt at the new local wall-clock
+ * times, and the user is told it happened.
+ */
+import { storage } from "../storage";
+import { STORAGE_KEYS } from "../config";
+
+export function getDeviceTimezone(): string {
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    if (tz) return tz;
+  } catch {
+    /* Intl unavailable — fall through to the offset form */
+  }
+  return `UTC${-new Date().getTimezoneOffset() / 60}`;
+}
+
+export interface TimezoneChange {
+  changed: boolean;
+  from?: string;
+  to: string;
+}
+
+/**
+ * Compares the device timezone with the last one seen and persists the
+ * current one. First run is never a "change". `current` is injectable for
+ * tests.
+ */
+export function detectTimezoneChange(current?: string): TimezoneChange {
+  const to = current ?? getDeviceTimezone();
+  const from = storage.getString(STORAGE_KEYS.LAST_TIMEZONE);
+  storage.set(STORAGE_KEYS.LAST_TIMEZONE, to);
+  if (!from || from === to) return { changed: false, to };
+  return { changed: true, from, to };
+}


### PR DESCRIPTION
## Qué hace

**Zona horaria (viajes)** — Fase 3, pulido de confiabilidad: los horarios son "de pared" (08:00 donde estés), pero las alarmas encoladas son instantes absolutos del huso donde se programaron. Al cruzar husos, sonaban a la hora equivocada.

- `detectTimezoneChange()` (MMKV, primera vez nunca es "cambio") corre dentro de `rescheduleAllNotifications` — que ya se ejecuta en cada foreground y en la tarea de background.
- Si el huso cambió: se cancelan **todas** las alarmas/notificaciones encoladas y se reconstruyen a la hora local nueva, más una notificación informativa única ("Ajustamos tus recordatorios a la hora local de {{tz}}").
- Las dosis ya resueltas no vuelven a sonar (lógica existente). Un fallo en el manejo de tz nunca rompe el rescheduling en sí.

## Validación

Jest **283/283** (4 tests nuevos), eslint limpio, tsc solo baseline. Sin cambios nativos.
Pendiente en dispositivo: cambiar el huso del sistema y foreground → verificar reconstrucción + notificación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
