### PR TITLE
feat(fhir): export FHIR R4 para clínicas (F3)

### DIFF
--- a/__tests__/fhirExport.test.ts
+++ b/__tests__/fhirExport.test.ts
@@ -1,0 +1,76 @@
+/**
+ * FHIR R4 bundle builder (F3) — pure core.
+ */
+import { buildFhirBundle } from "../src/services/fhirExport";
+import { makeMedication, makeSchedule } from "./factories";
+
+jest.mock("../src/db/database", () => ({
+  getActiveMedications: jest.fn(),
+  getSchedulesByMedication: jest.fn(),
+  getActiveAllergies: jest.fn(),
+  getProfiles: jest.fn(),
+}));
+jest.mock("expo-sharing", () => ({ shareAsync: jest.fn() }));
+
+const RXNORM = "http://www.nlm.nih.gov/research/umls/rxnorm";
+
+describe("buildFhirBundle", () => {
+  const profile = {
+    id: "default",
+    name: "Mamá",
+    color: "blue",
+    createdAt: "2026-01-01",
+    emergencyContactName: "Giuliano",
+    emergencyContactPhone: "+54 9 11 5555-5555",
+  };
+
+  it("builds Patient + MedicationStatement + AllergyIntolerance entries", () => {
+    const med = makeMedication({ id: "m1", name: "Enalapril", rxcui: "500", startDate: "2026-07-01" });
+    const sched = makeSchedule({ medicationId: "m1", time: "08:00" });
+    const bundle = buildFhirBundle(
+      profile,
+      "Mamá",
+      [{ med, schedules: [sched] }],
+      [{ id: "a1", name: "Penicilina", ingRxcui: "7980", createdAt: "2026-07-01" }],
+      "2026-07-23T12:00:00.000Z"
+    );
+
+    expect(bundle.resourceType).toBe("Bundle");
+    expect(bundle.type).toBe("collection");
+    const types = bundle.entry.map((e: { resource: { resourceType: string } }) => e.resource.resourceType);
+    expect(types).toEqual(["Patient", "MedicationStatement", "AllergyIntolerance"]);
+
+    const patient = bundle.entry[0].resource as never as {
+      name: { text: string }[];
+      contact: { telecom: { value: string }[] }[];
+    };
+    expect(patient.name[0].text).toBe("Mamá");
+    expect(patient.contact[0].telecom[0].value).toBe("+54 9 11 5555-5555");
+
+    const stmt = bundle.entry[1].resource as never as {
+      medicationCodeableConcept: { text: string; coding: { system: string; code: string }[] };
+      dosage: { text: string }[];
+      subject: { reference: string };
+    };
+    expect(stmt.medicationCodeableConcept.coding[0]).toEqual({ system: RXNORM, code: "500" });
+    expect(stmt.dosage[0].text).toContain("08:00");
+    expect(stmt.subject.reference).toBe("Patient/patient-1");
+
+    const allergy = bundle.entry[2].resource as never as {
+      code: { text: string; coding: { code: string }[] };
+    };
+    expect(allergy.code.text).toBe("Penicilina");
+    expect(allergy.code.coding[0].code).toBe("7980");
+  });
+
+  it("marks PRN meds asNeeded and omits codings without rxcui", () => {
+    const med = makeMedication({ id: "m1", name: "Ibuprofeno", isPRN: true, rxcui: undefined });
+    const bundle = buildFhirBundle(null, "Yo", [{ med, schedules: [] }], [], "2026-07-23T12:00:00.000Z");
+    const stmt = bundle.entry[1].resource as never as {
+      dosage: { asNeededBoolean?: boolean }[];
+      medicationCodeableConcept: { coding?: unknown };
+    };
+    expect(stmt.dosage[0].asNeededBoolean).toBe(true);
+    expect(stmt.medicationCodeableConcept.coding).toBeUndefined();
+  });
+});

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -12,6 +12,7 @@ import { useAppStore, ThemeMode } from "../../src/store";
 import { exportBackup, importBackup, BackupCancelledError, BackupFormatError } from "../../src/services/backup";
 import { generateAndShareReport } from "../../src/services/pdfReport";
 import { generateAndShareCaregiverSnapshot } from "../../src/services/caregiverSnapshot";
+import { generateAndShareFhirBundle } from "../../src/services/fhirExport";
 import { checkFullScreenIntentPermission, requestFullScreenIntentPermission, getAlarmSound, stopSoundPreview } from "expo-alarm";
 import type { AlarmSound } from "expo-alarm";
 import { useAppTheme } from "../../src/hooks/useAppTheme";
@@ -141,6 +142,7 @@ export default function SettingsScreen() {
   const [importing, setImporting] = useState(false);
   const [generatingPdf, setGeneratingPdf] = useState(false);
   const [generatingSnapshot, setGeneratingSnapshot] = useState(false);
+  const [exportingFhir, setExportingFhir] = useState(false);
   const { showToast } = useToast();
 
   // Multi-profile (F2)
@@ -378,6 +380,18 @@ export default function SettingsScreen() {
       Alert.alert(t("report.errorTitle"), msg || t("report.errorMsg"));
     } finally {
       setGeneratingPdf(false);
+    }
+  }
+
+  async function handleFhirExport() {
+    setExportingFhir(true);
+    try {
+      await generateAndShareFhirBundle();
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      Alert.alert(t("report.errorTitle"), msg || t("report.errorMsg"));
+    } finally {
+      setExportingFhir(false);
     }
   }
 
@@ -717,6 +731,16 @@ export default function SettingsScreen() {
             subtitle={t("settings.caregiverSnapshotSubtitle")}
             onPress={handleCaregiverSnapshot}
             loading={generatingSnapshot}
+          />
+          <Divider />
+          {/* FHIR R4 export (F3): interop with clinics/EHRs, read-only */}
+          <SettingRow
+            icon="share-outline"
+            iconColor={theme.accent}
+            title={t("fhir.settingsTitle")}
+            subtitle={t("fhir.settingsSubtitle")}
+            onPress={handleFhirExport}
+            loading={exportingFhir}
           />
         </View>
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -511,6 +511,12 @@ const en: TranslationShape = {
   },
 
   // ─── PDF report ─────────────────────────────────────────────────────────
+  fhir: {
+    settingsTitle: "Export for your doctor (FHIR)",
+    settingsSubtitle: "Standard HL7 FHIR file with the active profile's medications and allergies",
+    shareTitle: "Export FHIR",
+    prn: "as needed",
+  },
   timezone: {
     adjustedTitle: "Timezone change",
     adjustedBody: "We adjusted your reminders to local time in {{tz}}.",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -509,6 +509,12 @@ const es = {
   },
 
   // ─── Informe PDF ────────────────────────────────────────────────────────
+  fhir: {
+    settingsTitle: "Exportar para tu médico (FHIR)",
+    settingsSubtitle: "Archivo estándar HL7 FHIR con medicación y alergias del perfil activo",
+    shareTitle: "Exportar FHIR",
+    prn: "según necesidad",
+  },
   timezone: {
     adjustedTitle: "Cambio de huso horario",
     adjustedBody: "Ajustamos tus recordatorios a la hora local de {{tz}}.",

--- a/src/services/fhirExport.ts
+++ b/src/services/fhirExport.ts
@@ -1,0 +1,152 @@
+/**
+ * FHIR R4 export (F3): a `Bundle` (type "collection") with the active
+ * profile's Patient, MedicationStatement per active med, and
+ * AllergyIntolerance per recorded allergy — the interop format clinics and
+ * national health records actually consume. Shared as a JSON file via the
+ * share-sheet; 100% local, generated on demand.
+ *
+ * Scope note: read-only EXPORT. Live SMART-on-FHIR connectivity is an
+ * explicit non-goal (see product backlog).
+ */
+import * as Sharing from "expo-sharing";
+import { File, Paths } from "expo-file-system";
+import {
+  getActiveMedications,
+  getSchedulesByMedication,
+  getActiveAllergies,
+  getProfiles,
+} from "../db/database";
+import { getActiveProfileId } from "./profileStore";
+import i18n from "../i18n";
+import type { Allergy, Medication, Profile, Schedule } from "../types";
+
+function t(key: string): string {
+  return i18n.t(key) as string;
+}
+
+/** RxNorm system URI — our rxcui field is an RxNorm SXDG id. */
+const RXNORM = "http://www.nlm.nih.gov/research/umls/rxnorm";
+
+function patientResource(profile: Profile | null, displayName: string) {
+  return {
+    resourceType: "Patient",
+    id: "patient-1",
+    name: [{ text: displayName }],
+    ...(profile?.emergencyContactPhone
+      ? {
+          contact: [
+            {
+              name: { text: profile.emergencyContactName ?? "" },
+              telecom: [{ system: "phone", value: profile.emergencyContactPhone }],
+            },
+          ],
+        }
+      : {}),
+  };
+}
+
+function medicationStatementResource(med: Medication, schedules: Schedule[], index: number) {
+  const timings = schedules.filter((s) => s.isActive).map((s) => s.time);
+  return {
+    resourceType: "MedicationStatement",
+    id: `medstmt-${index}`,
+    status: "active",
+    subject: { reference: "Patient/patient-1" },
+    medicationCodeableConcept: {
+      text: med.name,
+      ...(med.rxcui ? { coding: [{ system: RXNORM, code: med.rxcui }] } : {}),
+    },
+    ...(med.startDate ? { effectivePeriod: { start: med.startDate, ...(med.endDate ? { end: med.endDate } : {}) } } : {}),
+    dosage: [
+      {
+        text: med.isPRN
+          ? `${med.dosage} — ${t("fhir.prn")}`
+          : `${med.dosage}${timings.length ? ` — ${timings.join(", ")}` : ""}`,
+        ...(med.isPRN ? { asNeededBoolean: true } : {}),
+      },
+    ],
+    ...(med.notes ? { note: [{ text: med.notes }] } : {}),
+  };
+}
+
+function allergyResource(allergy: Allergy, index: number) {
+  return {
+    resourceType: "AllergyIntolerance",
+    id: `allergy-${index}`,
+    patient: { reference: "Patient/patient-1" },
+    clinicalStatus: {
+      coding: [
+        {
+          system: "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+          code: "active",
+        },
+      ],
+    },
+    code: {
+      text: allergy.name,
+      ...(allergy.ingRxcui ? { coding: [{ system: RXNORM, code: allergy.ingRxcui }] } : {}),
+    },
+  };
+}
+
+/** Pure builder — testable without native modules. */
+export function buildFhirBundle(
+  profile: Profile | null,
+  displayName: string,
+  meds: { med: Medication; schedules: Schedule[] }[],
+  allergies: Allergy[],
+  generatedAt: string
+) {
+  const entries = [
+    { resource: patientResource(profile, displayName) },
+    ...meds.map((m, i) => ({ resource: medicationStatementResource(m.med, m.schedules, i + 1) })),
+    ...allergies.map((a, i) => ({ resource: allergyResource(a, i + 1) })),
+  ];
+  return {
+    resourceType: "Bundle",
+    type: "collection",
+    timestamp: generatedAt,
+    entry: entries,
+  };
+}
+
+export async function generateAndShareFhirBundle(): Promise<void> {
+  const [profiles, meds, allergies] = await Promise.all([
+    getProfiles(),
+    getActiveMedications(),
+    getActiveAllergies(),
+  ]);
+  const profile = profiles.find((p) => p.id === getActiveProfileId()) ?? null;
+  const displayName = profile?.name || (i18n.t("profiles.me") as string);
+
+  const activeMeds = meds.filter((m) => m.isActive);
+  const withSchedules = [];
+  for (const med of activeMeds) {
+    withSchedules.push({ med, schedules: await getSchedulesByMedication(med.id) });
+  }
+
+  const bundle = buildFhirBundle(
+    profile,
+    displayName,
+    withSchedules,
+    allergies,
+    new Date().toISOString()
+  );
+
+  const date = new Date().toISOString().slice(0, 10);
+  const file = new File(Paths.cache, `pilloclock-fhir-${date}.json`);
+  try {
+    file.write(JSON.stringify(bundle, null, 2));
+    await Sharing.shareAsync(file.uri, {
+      mimeType: "application/fhir+json",
+      dialogTitle: t("fhir.shareTitle"),
+    });
+  } finally {
+    // Health data must not linger in cache (audit L8). Best-effort.
+    try {
+      file.delete();
+    } catch {
+      /* ignore */
+    }
+  }
+}


### PR DESCRIPTION
## Qué hace

**Export FHIR R4** (Fase 3): Ajustes → Tus datos → "Exportar para tu médico (FHIR)". Genera un **Bundle HL7 FHIR R4** (collection) del perfil activo y lo comparte por share-sheet como `application/fhir+json`:

- `Patient` (con el contacto de emergencia como `Patient.contact`),
- `MedicationStatement` por medicamento activo — con coding **RxNorm** cuando capturamos rxcui, horarios en el texto de dosis, `asNeededBoolean` para PRN y `effectivePeriod` de las fechas,
- `AllergyIntolerance` por alergia (coding RxNorm si está anclada a ingrediente).

100% local, generado on demand; el archivo temporal se borra del cache tras compartir (audit L8). El SMART-on-FHIR en vivo sigue siendo non-goal explícito.

## Validación

Jest **285/285** (builder puro testeado), eslint limpio, tsc solo baseline. Sin cambios nativos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
