### PR TITLE
feat(backup): backups cifrados con contraseña a la nube propia (F3)

### DIFF
--- a/__tests__/backupCrypto.test.ts
+++ b/__tests__/backupCrypto.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Passphrase encryption for backups (F3): round-trip, wrong passphrase,
+ * tamper detection, envelope detection.
+ */
+import {
+  encryptBackup,
+  decryptBackup,
+  isEncryptedEnvelope,
+  WrongPassphraseError,
+  ENCRYPTED_BACKUP_MARKER,
+  type EncryptedEnvelope,
+} from "../src/services/backupCrypto";
+
+const SAMPLE = JSON.stringify({ app: "pill-o-clock", version: 3, data: { medications: [] } });
+
+describe("encryptBackup / decryptBackup", () => {
+  it("round-trips under the right passphrase", () => {
+    const envelope = JSON.parse(encryptBackup(SAMPLE, "correct horse")) as EncryptedEnvelope;
+    expect(envelope.app).toBe(ENCRYPTED_BACKUP_MARKER);
+    expect(envelope.kdf).toBe("scrypt");
+    expect(decryptBackup(envelope, "correct horse")).toBe(SAMPLE);
+  });
+
+  it("ciphertext does not contain the plaintext", () => {
+    const envelope = JSON.parse(encryptBackup(SAMPLE, "s3cret!")) as EncryptedEnvelope;
+    expect(envelope.ct).not.toContain("pill-o-clock");
+    expect(JSON.stringify(envelope)).not.toContain("medications");
+  });
+
+  it("rejects a wrong passphrase", () => {
+    const envelope = JSON.parse(encryptBackup(SAMPLE, "right")) as EncryptedEnvelope;
+    expect(() => decryptBackup(envelope, "wrong")).toThrow(WrongPassphraseError);
+  });
+
+  it("rejects a tampered ciphertext (Poly1305 auth)", () => {
+    const envelope = JSON.parse(encryptBackup(SAMPLE, "pass-123")) as EncryptedEnvelope;
+    const bytes = Uint8Array.from(atob(envelope.ct), (c) => c.charCodeAt(0));
+    bytes[0] ^= 0xff;
+    envelope.ct = btoa(String.fromCharCode(...bytes));
+    expect(() => decryptBackup(envelope, "pass-123")).toThrow(WrongPassphraseError);
+  });
+});
+
+describe("isEncryptedEnvelope", () => {
+  it("detects envelopes and rejects plain backups", () => {
+    const envelope = JSON.parse(encryptBackup(SAMPLE, "x-pass-1"));
+    expect(isEncryptedEnvelope(envelope)).toBe(true);
+    expect(isEncryptedEnvelope(JSON.parse(SAMPLE))).toBe(false);
+    expect(isEncryptedEnvelope(null)).toBe(false);
+    expect(isEncryptedEnvelope("string")).toBe(false);
+  });
+});

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -9,7 +9,8 @@ import { useFocusEffect, useRouter } from "expo-router";
 import Constants from "expo-constants";
 import { useTranslation, changeLanguage } from "../../src/i18n";
 import { useAppStore, ThemeMode } from "../../src/store";
-import { exportBackup, importBackup, BackupCancelledError, BackupFormatError } from "../../src/services/backup";
+import { exportBackup, importBackup, BackupCancelledError, BackupFormatError, WrongPassphraseError } from "../../src/services/backup";
+import { PassphraseModal } from "../../components/PassphraseModal";
 import { generateAndShareReport } from "../../src/services/pdfReport";
 import { generateAndShareCaregiverSnapshot } from "../../src/services/caregiverSnapshot";
 import { generateAndShareFhirBundle } from "../../src/services/fhirExport";
@@ -143,6 +144,13 @@ export default function SettingsScreen() {
   const [generatingPdf, setGeneratingPdf] = useState(false);
   const [generatingSnapshot, setGeneratingSnapshot] = useState(false);
   const [exportingFhir, setExportingFhir] = useState(false);
+  // Passphrase prompt (F3 encrypted backup): promise resolved by the modal.
+  const [passModal, setPassModal] = useState<{
+    mode: "set" | "enter";
+    resolve: (pass: string | null) => void;
+  } | null>(null);
+  const promptPassphrase = (mode: "set" | "enter") =>
+    new Promise<string | null>((resolve) => setPassModal({ mode, resolve }));
   const { showToast } = useToast();
 
   // Multi-profile (F2)
@@ -322,9 +330,11 @@ export default function SettingsScreen() {
   }
 
   async function handleExport() {
+    // Optional passphrase (F3): skip = plain JSON, exactly as before.
+    const passphrase = await promptPassphrase("set");
     setExporting(true);
     try {
-      await exportBackup();
+      await exportBackup(passphrase ?? undefined);
       showToast(t("settings.exportSuccess"), "success");
     } catch (e) {
       if (e instanceof BackupCancelledError) return;
@@ -356,15 +366,17 @@ export default function SettingsScreen() {
   async function runImport(mode: "replace" | "merge") {
     setImporting(true);
     try {
-      const { count } = await importBackup(mode);
+      const { count } = await importBackup(mode, () => promptPassphrase("enter"));
       await loadAll();
       showToast(t("settings.importSuccessMsg", { count }), "success");
     } catch (e) {
       if (e instanceof BackupCancelledError) return;
       const msg =
-        e instanceof BackupFormatError
-          ? t("settings.importErrorFormat")
-          : t("settings.importErrorGeneric");
+        e instanceof WrongPassphraseError
+          ? t("backupCrypto.wrongPassphrase")
+          : e instanceof BackupFormatError
+            ? t("settings.importErrorFormat")
+            : t("settings.importErrorGeneric");
       showToast(msg, "error");
     } finally {
       setImporting(false);
@@ -833,6 +845,16 @@ export default function SettingsScreen() {
           />
         </View>
       </ScrollView>
+
+      {/* Backup passphrase prompt (F3 encrypted backup) */}
+      <PassphraseModal
+        visible={passModal !== null}
+        mode={passModal?.mode ?? "set"}
+        onDone={(pass) => {
+          passModal?.resolve(pass);
+          setPassModal(null);
+        }}
+      />
 
       {/* Profile create/edit modal (F2 multi-profile) */}
       <ProfileModal

--- a/components/PassphraseModal.tsx
+++ b/components/PassphraseModal.tsx
@@ -1,0 +1,95 @@
+/**
+ * PassphraseModal (F3 encrypted backup).
+ *  - mode "set": choosing a passphrase for export — optional (skip = plain).
+ *  - mode "enter": unlocking an encrypted backup on import — required.
+ */
+import { View, Text, TextInput, TouchableOpacity, Modal } from "react-native";
+import { useEffect, useState } from "react";
+import { Ionicons } from "@expo/vector-icons";
+import { useTranslation } from "../src/i18n";
+import { useAppTheme } from "../src/hooks/useAppTheme";
+
+interface Props {
+  visible: boolean;
+  mode: "set" | "enter";
+  /** null = user skipped (set-mode) or cancelled. */
+  onDone: (passphrase: string | null) => void;
+}
+
+const MIN_LEN = 6;
+
+export function PassphraseModal({ visible, mode, onDone }: Props) {
+  const { t } = useTranslation();
+  const theme = useAppTheme();
+  const [pass, setPass] = useState("");
+  const [confirm, setConfirm] = useState("");
+
+  useEffect(() => {
+    if (visible) {
+      setPass("");
+      setConfirm("");
+    }
+  }, [visible]);
+
+  const canConfirm =
+    mode === "enter" ? pass.length > 0 : pass.length >= MIN_LEN && pass === confirm;
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={() => onDone(null)}>
+      <View className="flex-1 items-center justify-center bg-black/50 px-8">
+        <View className="w-full rounded-2xl bg-card p-5">
+          <View className="flex-row items-center gap-2 mb-1">
+            <Ionicons name="lock-closed-outline" size={18} color={theme.primary} />
+            <Text className="text-lg font-bold text-text">
+              {mode === "set" ? t("backupCrypto.setTitle") : t("backupCrypto.enterTitle")}
+            </Text>
+          </View>
+          <Text className="text-xs text-muted mb-4">
+            {mode === "set" ? t("backupCrypto.setSubtitle") : t("backupCrypto.enterSubtitle")}
+          </Text>
+
+          <TextInput
+            value={pass}
+            onChangeText={setPass}
+            placeholder={t("backupCrypto.passphrasePlaceholder")}
+            placeholderTextColor={theme.muted}
+            secureTextEntry
+            autoFocus
+            className="border border-border rounded-xl px-3 py-2.5 text-text text-base bg-card-alt"
+          />
+          {mode === "set" && (
+            <TextInput
+              value={confirm}
+              onChangeText={setConfirm}
+              placeholder={t("backupCrypto.confirmPlaceholder")}
+              placeholderTextColor={theme.muted}
+              secureTextEntry
+              className="border border-border rounded-xl px-3 py-2.5 text-text text-base bg-card-alt mt-2"
+            />
+          )}
+          {mode === "set" && (
+            <Text className="text-[11px] text-muted mt-2">{t("backupCrypto.warning")}</Text>
+          )}
+
+          <View className="flex-row items-center justify-end mt-4 gap-3">
+            <TouchableOpacity onPress={() => onDone(null)} className="py-2.5 px-4">
+              <Text className="text-muted font-semibold">
+                {mode === "set" ? t("backupCrypto.skip") : t("common.cancel")}
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              accessibilityRole="button"
+              disabled={!canConfirm}
+              onPress={() => onDone(pass)}
+              className={`rounded-xl py-2.5 px-5 ${canConfirm ? "bg-primary" : "bg-slate-300"}`}
+            >
+              <Text className="text-white font-bold">
+                {mode === "set" ? t("backupCrypto.encrypt") : t("backupCrypto.unlock")}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   // Only treat *.test.* and *.spec.* files as test suites (excludes helpers like factories.ts)
   testMatch: ["**/?(*.)+(spec|test).[jt]s?(x)"],
   transformIgnorePatterns: [
-    "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|nativewind|react-native-css-interop|date-fns)",
+    "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|nativewind|react-native-css-interop|date-fns|@noble/.*)",
   ],
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   // Claude Code worktrees under .claude/ contain a full copy of the repo;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@hookform/resolvers": "^5.2.2",
+        "@noble/ciphers": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/datetimepicker": "8.4.4",
         "@react-native-community/slider": "5.0.1",
@@ -4702,6 +4704,30 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
     "@hookform/resolvers": "^5.2.2",
+    "@noble/ciphers": "^2.2.0",
+    "@noble/hashes": "^2.2.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/datetimepicker": "8.4.4",
     "@react-native-community/slider": "5.0.1",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -511,6 +511,19 @@ const en: TranslationShape = {
   },
 
   // ─── PDF report ─────────────────────────────────────────────────────────
+  backupCrypto: {
+    setTitle: "Protect with a passphrase?",
+    setSubtitle: "The file is encrypted: nobody can read it without the passphrase, not even where you store it (Drive, etc.).",
+    enterTitle: "Encrypted backup",
+    enterSubtitle: "Enter the passphrase this backup was created with.",
+    passphrasePlaceholder: "Passphrase (min. 6 characters)",
+    confirmPlaceholder: "Repeat passphrase",
+    warning: "If you forget it, the backup cannot be recovered. We store it nowhere.",
+    skip: "No passphrase",
+    encrypt: "Encrypt",
+    unlock: "Open",
+    wrongPassphrase: "Wrong passphrase or corrupted file.",
+  },
   fhir: {
     settingsTitle: "Export for your doctor (FHIR)",
     settingsSubtitle: "Standard HL7 FHIR file with the active profile's medications and allergies",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -509,6 +509,19 @@ const es = {
   },
 
   // ─── Informe PDF ────────────────────────────────────────────────────────
+  backupCrypto: {
+    setTitle: "¿Proteger con contraseña?",
+    setSubtitle: "El archivo queda cifrado: nadie puede leerlo sin la contraseña, ni siquiera donde lo guardes (Drive, etc.).",
+    enterTitle: "Backup cifrado",
+    enterSubtitle: "Ingresá la contraseña con la que se creó este backup.",
+    passphrasePlaceholder: "Contraseña (mín. 6 caracteres)",
+    confirmPlaceholder: "Repetir contraseña",
+    warning: "Si la olvidás, no hay forma de recuperar el backup. No la guardamos en ningún lado.",
+    skip: "Sin contraseña",
+    encrypt: "Cifrar",
+    unlock: "Abrir",
+    wrongPassphrase: "Contraseña incorrecta o archivo dañado.",
+  },
   fhir: {
     settingsTitle: "Exportar para tu médico (FHIR)",
     settingsSubtitle: "Archivo estándar HL7 FHIR con medicación y alergias del perfil activo",

--- a/src/services/backup.ts
+++ b/src/services/backup.ts
@@ -2,6 +2,7 @@ import { File, Paths } from "expo-file-system";
 import { StorageAccessFramework } from "expo-file-system/src/legacy";
 import * as DocumentPicker from "expo-document-picker";
 import { z } from "zod";
+import { encryptBackup, decryptBackup, isEncryptedEnvelope, WrongPassphraseError } from "./backupCrypto";
 import { Medication, Schedule, DoseLog, Appointment, AppointmentDocument, HealthMeasurement, DailyCheckin, Allergy } from "../types";
 import {
   getDb,
@@ -166,7 +167,7 @@ export type BackupData = z.infer<typeof backupSchema>;
 
 /** Serialises the entire database into a JSON file and lets the user
  *  pick a folder via the system file picker (SAF) to save it. */
-export async function exportBackup(): Promise<void> {
+export async function exportBackup(passphrase?: string): Promise<void> {
   const [medications, schedules, doseLogs, appointments, appointmentDocuments, healthMeasurements, dailyCheckins, profiles, allergies] = await Promise.all([
     getMedications(),
     getAllSchedules(),
@@ -186,9 +187,14 @@ export async function exportBackup(): Promise<void> {
     data: { medications, schedules, doseLogs, appointments, appointmentDocuments, healthMeasurements, dailyCheckins, profiles, allergies },
   };
 
-  const json = JSON.stringify(backup, null, 2);
+  const plain = JSON.stringify(backup, null, 2);
+  // Optional passphrase (F3): scrypt + XChaCha20-Poly1305 envelope so the
+  // file is unreadable wherever the SAF picker puts it (user's own cloud).
+  const json = passphrase ? encryptBackup(plain, passphrase) : plain;
   const date = new Date().toISOString().split("T")[0];
-  const filename = `pilloclock-backup-${date}`;
+  const filename = passphrase
+    ? `pilloclock-backup-${date}.encrypted`
+    : `pilloclock-backup-${date}`;
 
   const permissions = await StorageAccessFramework.requestDirectoryPermissionsAsync();
   if (!permissions.granted) throw new BackupCancelledError();
@@ -226,7 +232,10 @@ export class BackupFormatError extends Error {
  * @returns `{ count }` — number of medications that were imported.
  */
 export async function importBackup(
-  mode: "replace" | "merge"
+  mode: "replace" | "merge",
+  /** Called when the picked file is a passphrase-encrypted envelope.
+   *  Resolve null to cancel the import. */
+  getPassphrase?: () => Promise<string | null>
 ): Promise<{ count: number }> {
   const result = await DocumentPicker.getDocumentAsync({
     type: ["application/json", "text/plain", "*/*"],
@@ -246,6 +255,19 @@ export async function importBackup(
       raw = JSON.parse(json);
     } catch {
       throw new BackupFormatError();
+    }
+
+    // Encrypted envelope (F3): ask for the passphrase and unwrap.
+    if (isEncryptedEnvelope(raw)) {
+      if (!getPassphrase) throw new BackupFormatError();
+      const passphrase = await getPassphrase();
+      if (passphrase == null) throw new BackupCancelledError();
+      const decrypted = decryptBackup(raw, passphrase); // throws WrongPassphraseError
+      try {
+        raw = JSON.parse(decrypted);
+      } catch {
+        throw new BackupFormatError();
+      }
     }
 
     const parsed = backupSchema.safeParse(raw);
@@ -347,3 +369,5 @@ export async function importBackup(
     }
   }
 }
+
+export { WrongPassphraseError };

--- a/src/services/backupCrypto.ts
+++ b/src/services/backupCrypto.ts
@@ -1,0 +1,129 @@
+/**
+ * Passphrase encryption for backups (F3 — "own-cloud" encrypted backup).
+ *
+ * The existing export already reaches the user's Drive/cloud through the
+ * system SAF picker; this adds an optional passphrase so the file is
+ * unreadable at rest wherever it lands. Pure JS (@noble/*, audited):
+ * scrypt (N=2^14, r=8, p=1) → XChaCha20-Poly1305. Never our servers,
+ * never our keys — decision D1.
+ *
+ * Envelope (JSON):
+ *   { app: "pill-o-clock-encrypted", v: 1, kdf: "scrypt",
+ *     n, r, p, salt, nonce, ct }           // salt/nonce/ct base64
+ */
+import { xchacha20poly1305 } from "@noble/ciphers/chacha.js";
+import { utf8ToBytes, bytesToUtf8 } from "@noble/ciphers/utils.js";
+import { scrypt } from "@noble/hashes/scrypt.js";
+import * as Crypto from "expo-crypto";
+
+export const ENCRYPTED_BACKUP_MARKER = "pill-o-clock-encrypted";
+
+const SCRYPT_PARAMS = { N: 2 ** 14, r: 8, p: 1, dkLen: 32 };
+
+export class WrongPassphraseError extends Error {
+  constructor() {
+    super("wrong_passphrase");
+  }
+}
+
+export interface EncryptedEnvelope {
+  app: typeof ENCRYPTED_BACKUP_MARKER;
+  v: 1;
+  kdf: "scrypt";
+  n: number;
+  r: number;
+  p: number;
+  salt: string;
+  nonce: string;
+  ct: string;
+}
+
+// Hermes has no btoa/atob and TextDecoder is not guaranteed — hand-rolled
+// base64 + @noble utf8 helpers keep this dependency-free and device-safe.
+const B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+function toB64(bytes: Uint8Array): string {
+  let out = "";
+  for (let i = 0; i < bytes.length; i += 3) {
+    const a = bytes[i];
+    const b = i + 1 < bytes.length ? bytes[i + 1] : 0;
+    const c = i + 2 < bytes.length ? bytes[i + 2] : 0;
+    out += B64[a >> 2] + B64[((a & 3) << 4) | (b >> 4)];
+    out += i + 1 < bytes.length ? B64[((b & 15) << 2) | (c >> 6)] : "=";
+    out += i + 2 < bytes.length ? B64[c & 63] : "=";
+  }
+  return out;
+}
+
+function fromB64(b64: string): Uint8Array {
+  const clean = b64.replace(/=+$/, "");
+  const out = new Uint8Array(Math.floor((clean.length * 3) / 4));
+  let acc = 0;
+  let bits = 0;
+  let j = 0;
+  for (const ch of clean) {
+    const v = B64.indexOf(ch);
+    if (v === -1) throw new Error("invalid base64");
+    acc = (acc << 6) | v;
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      out[j++] = (acc >> bits) & 0xff;
+    }
+  }
+  return out;
+}
+
+const utf8 = {
+  encode: (s: string) => utf8ToBytes(s),
+  decode: (b: Uint8Array) => bytesToUtf8(b),
+};
+
+/** Encrypts a backup JSON string under a passphrase. */
+export function encryptBackup(json: string, passphrase: string): string {
+  const salt = Crypto.getRandomBytes(16);
+  const nonce = Crypto.getRandomBytes(24);
+  const key = scrypt(utf8.encode(passphrase), salt, SCRYPT_PARAMS);
+  const ct = xchacha20poly1305(key, nonce).encrypt(utf8.encode(json));
+  const envelope: EncryptedEnvelope = {
+    app: ENCRYPTED_BACKUP_MARKER,
+    v: 1,
+    kdf: "scrypt",
+    n: SCRYPT_PARAMS.N,
+    r: SCRYPT_PARAMS.r,
+    p: SCRYPT_PARAMS.p,
+    salt: toB64(salt),
+    nonce: toB64(nonce),
+    ct: toB64(ct),
+  };
+  return JSON.stringify(envelope);
+}
+
+/** Detects our envelope shape without attempting decryption. */
+export function isEncryptedEnvelope(raw: unknown): raw is EncryptedEnvelope {
+  return (
+    typeof raw === "object" &&
+    raw !== null &&
+    (raw as EncryptedEnvelope).app === ENCRYPTED_BACKUP_MARKER &&
+    typeof (raw as EncryptedEnvelope).ct === "string"
+  );
+}
+
+/**
+ * Decrypts an envelope back to the backup JSON string. Wrong passphrase or
+ * tampering (Poly1305 auth failure) → WrongPassphraseError.
+ */
+export function decryptBackup(envelope: EncryptedEnvelope, passphrase: string): string {
+  const key = scrypt(utf8.encode(passphrase), fromB64(envelope.salt), {
+    N: envelope.n,
+    r: envelope.r,
+    p: envelope.p,
+    dkLen: 32,
+  });
+  try {
+    const pt = xchacha20poly1305(key, fromB64(envelope.nonce)).decrypt(fromB64(envelope.ct));
+    return utf8.decode(pt);
+  } catch {
+    throw new WrongPassphraseError();
+  }
+}


### PR DESCRIPTION
## Qué hace

**Backup cifrado a la nube propia** (Fase 3, decisión D1: jamás nuestros servidores, jamás nuestras claves). El export existente ya llega al Drive del usuario vía el picker del sistema (SAF) — esto agrega una **contraseña opcional** para que el archivo sea ilegible en reposo donde sea que termine.

- **Criptografía**: scrypt (N=2¹⁴) → XChaCha20-Poly1305, JS puro con `@noble/ciphers` + `@noble/hashes` (auditadas, sin deps nativas). Hermes-safe: base64 propio + helpers utf8 de noble (sin `btoa`/`TextDecoder`).
- **Export**: modal "¿Proteger con contraseña?" — omitir mantiene el JSON plano de siempre; con contraseña el archivo sale `*.encrypted` con advertencia honesta de no-recuperación.
- **Import**: detecta el sobre cifrado, pide la contraseña, y una contraseña incorrecta o un archivo adulterado (autenticación Poly1305) dan el mismo error específico.

## Validación

Jest **290/290** (5 tests: round-trip, contraseña errónea, adulteración, detección de sobre, no-fuga de plaintext), eslint limpio, tsc solo baseline. Sin cambios nativos.
Pendiente en dispositivo: export cifrado a Drive + reimport (tiempo de scrypt en gama baja).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
