### PR TITLE
feat(tts): alarmas habladas — leer med y dosis en voz alta (F4)

### DIFF
--- a/__tests__/tts.test.ts
+++ b/__tests__/tts.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Spoken alarms (F4 TTS): opt-in gating, language mapping, speech content.
+ */
+import * as Speech from "expo-speech";
+import { isTtsEnabled, setTtsEnabled, speakDoseReminder, stopSpeaking, ttsLanguage } from "../src/services/tts";
+import { initI18n } from "../src/i18n";
+
+jest.mock("expo-localization", () => ({
+  getLocales: () => [{ languageCode: "es" }],
+}));
+
+beforeAll(() => initI18n());
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setTtsEnabled(false);
+});
+
+describe("speakDoseReminder", () => {
+  it("stays silent while disabled (opt-in)", () => {
+    speakDoseReminder("Enalapril", "10 mg");
+    expect(jest.mocked(Speech.speak)).not.toHaveBeenCalled();
+  });
+
+  it("speaks name + dose in the app language when enabled", () => {
+    setTtsEnabled(true);
+    speakDoseReminder("Enalapril", "10 mg");
+    expect(jest.mocked(Speech.speak)).toHaveBeenCalledTimes(1);
+    const [text, opts] = jest.mocked(Speech.speak).mock.calls[0];
+    expect(text).toContain("Enalapril");
+    expect(text).toContain("10 mg");
+    expect(opts).toMatchObject({ language: "es-ES" });
+  });
+
+  it("maps app languages to BCP-47 voices", () => {
+    expect(ttsLanguage()).toBe("es-ES");
+  });
+
+  it("stopSpeaking delegates to the engine", () => {
+    stopSpeaking();
+    expect(jest.mocked(Speech.stop)).toHaveBeenCalled();
+  });
+});

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -32,6 +32,7 @@ import {
 } from "../../src/services/appLock";
 import { PinModal } from "../../components/PinModal";
 import { isHealthSyncSupported, isHealthSyncEnabled, enableHealthSync, disableHealthSync } from "../../src/services/healthSync";
+import { isTtsEnabled, setTtsEnabled } from "../../src/services/tts";
 import { ProfileModal } from "../../components/ProfileModal";
 import { MEDICATION_COLORS } from "../../src/utils";
 import type { Profile } from "../../src/types";
@@ -144,6 +145,7 @@ export default function SettingsScreen() {
   const [generatingPdf, setGeneratingPdf] = useState(false);
   const [generatingSnapshot, setGeneratingSnapshot] = useState(false);
   const [exportingFhir, setExportingFhir] = useState(false);
+  const [ttsOn, setTtsOn] = useState(isTtsEnabled);
   // Passphrase prompt (F3 encrypted backup): promise resolved by the modal.
   const [passModal, setPassModal] = useState<{
     mode: "set" | "enter";
@@ -806,6 +808,25 @@ export default function SettingsScreen() {
               onValueChange={(on) => { Haptics.selectionAsync(); setSeniorMode(on); }}
               trackColor={{ false: undefined, true: theme.primary }}
               accessibilityLabel={t("settings.seniorMode")}
+            />
+          </View>
+          {/* Spoken alarms (F4 TTS) — opt-in accessibility */}
+          <Divider />
+          <View className="flex-row items-center px-4 py-3.5 gap-3">
+            <Ionicons name="volume-high-outline" size={20} color={theme.primary} />
+            <View className="flex-1">
+              <Text className="text-[15px] font-semibold text-text">{t("settings.tts")}</Text>
+              <Text className="text-xs text-muted mt-0.5 leading-4">{t("settings.ttsSubtitle")}</Text>
+            </View>
+            <Switch
+              value={ttsOn}
+              onValueChange={(on) => {
+                Haptics.selectionAsync();
+                setTtsEnabled(on);
+                setTtsOn(on);
+              }}
+              trackColor={{ false: undefined, true: theme.primary }}
+              accessibilityLabel={t("settings.tts")}
             />
           </View>
         </View>

--- a/app/alarm.tsx
+++ b/app/alarm.tsx
@@ -9,6 +9,7 @@ import { SNOOZE_OPTIONS, getDefaultSnoozeMinutes } from "../src/services/snoozeS
 import { useTranslation } from "../src/i18n";
 import { stopAlarm, setAlarmWindowFlags, clearAlarmWindowFlags } from "expo-alarm";
 import { getMedications } from "../src/db/database";
+import { speakDoseReminder, stopSpeaking } from "../src/services/tts";
 import type { Medication } from "../src/types";
 import { AppPressable } from "../components/AppPressable";
 import { useAppTheme } from "../src/hooks/useAppTheme";
@@ -85,8 +86,19 @@ export default function AlarmScreen() {
     stopAlarm().catch(() => {}); // stop audio as soon as the screen mounts
     return () => {
       clearAlarmWindowFlags().catch(() => {});
+      stopSpeaking(); // cut any ongoing spoken reminder (F4 TTS)
     };
   }, []);
+
+  // Spoken reminder (F4 TTS, opt-in): read the med + dose aloud once the
+  // alarm audio stopped and the med is resolved. Never on quick-actions.
+  const spokeRef = useRef(false);
+  useEffect(() => {
+    if (action || !medication || spokeRef.current) return;
+    spokeRef.current = true;
+    speakDoseReminder(medication.name, getLocalizedDosage(medication, t));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [medication, action]);
 
   // Block the hardware back button while the alarm screen is active.
   // This also suppresses the Android 14+ predictive back gesture preview
@@ -202,12 +214,14 @@ export default function AlarmScreen() {
   };
 
   const handleTake = async () => {
+    stopSpeaking();
     await stopAlarm();
     await markDose(dose, "taken", noteText.trim() || undefined);
     router.back();
   };
 
   const handleSkip = async () => {
+    stopSpeaking();
     await stopAlarm();
     await markDose(dose, "skipped", noteText.trim() || undefined);
     router.back();
@@ -218,6 +232,7 @@ export default function AlarmScreen() {
   const defaultSnoozeMinutes = getDefaultSnoozeMinutes();
 
   const handleSnooze = async (minutes: number = defaultSnoozeMinutes) => {
+    stopSpeaking();
     await stopAlarm();
     await snoozeDose(dose, minutes);
     router.back();

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -78,6 +78,12 @@ jest.mock("expo-camera", () => ({
   ]),
 }));
 
+// ─── expo-speech (spoken alarms, F4) ───────────────────────────────────────
+jest.mock("expo-speech", () => ({
+  speak: jest.fn(),
+  stop: jest.fn(),
+}));
+
 // ─── expo-local-authentication ─────────────────────────────────────────────
 jest.mock("expo-local-authentication", () => ({
   hasHardwareAsync: jest.fn().mockResolvedValue(false),

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "expo-router": "~6.0.23",
         "expo-secure-store": "~15.0.8",
         "expo-sharing": "~14.0.8",
+        "expo-speech": "~14.0.8",
         "expo-splash-screen": "~31.0.13",
         "expo-sqlite": "~16.0.10",
         "expo-status-bar": "~3.0.9",
@@ -10597,6 +10598,15 @@
       "version": "14.0.8",
       "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-14.0.8.tgz",
       "integrity": "sha512-A1pPr2iBrxypFDCWVAESk532HK+db7MFXbvO2sCV9ienaFXAk7lIBm6bkqgE6vzRd9O3RGdEGzYx80cYlc089Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-speech": {
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/expo-speech/-/expo-speech-14.0.8.tgz",
+      "integrity": "sha512-UjBFCFv58nutlLw92L7kUS0ZjbOOfaTdiEv/HbjvMrT6BfldoOLLBZbaEcEhDdZK36NY/kass0Kzxk+co6vxSQ==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "expo-router": "~6.0.23",
     "expo-secure-store": "~15.0.8",
     "expo-sharing": "~14.0.8",
+    "expo-speech": "~14.0.8",
     "expo-splash-screen": "~31.0.13",
     "expo-sqlite": "~16.0.10",
     "expo-status-bar": "~3.0.9",

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,7 @@ export const STORAGE_KEYS = {
   HEALTH_SYNC:                "@pilloclock/health_sync",
   ACTIVE_PROFILE:             "@pilloclock/active_profile",
   LAST_TIMEZONE:              "@pilloclock/last_timezone",
+  TTS_ENABLED:                "@pilloclock/tts_enabled",
   RECENT_COLORS:            "custom_colors_recent",
   // Legacy keys kept for migration only (notifications.ts)
   NOTIF_MAP:                "@pilloclock/notif_map",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -511,6 +511,9 @@ const en: TranslationShape = {
   },
 
   // ─── PDF report ─────────────────────────────────────────────────────────
+  tts: {
+    alarmSpeech: "Time to take {{name}}, {{dose}}.",
+  },
   backupCrypto: {
     setTitle: "Protect with a passphrase?",
     setSubtitle: "The file is encrypted: nobody can read it without the passphrase, not even where you store it (Drive, etc.).",
@@ -755,6 +758,8 @@ const en: TranslationShape = {
     rxtermsAttribution: "Medication name suggestions include RxTerms data, produced by the U.S. National Library of Medicine.",
     // Appearance
     sectionAppearance: "Appearance",
+    tts: "Read alarms aloud",
+    ttsSubtitle: "When the alarm rings, the phone says the medication and dose",
     seniorMode: "Large text & buttons",
     seniorModeSubtitle: "Enhanced-visibility mode for dose cards",
     themeSystem: "Automatic (system)",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -509,6 +509,9 @@ const es = {
   },
 
   // ─── Informe PDF ────────────────────────────────────────────────────────
+  tts: {
+    alarmSpeech: "Hora de tomar {{name}}, {{dose}}.",
+  },
   backupCrypto: {
     setTitle: "¿Proteger con contraseña?",
     setSubtitle: "El archivo queda cifrado: nadie puede leerlo sin la contraseña, ni siquiera donde lo guardes (Drive, etc.).",
@@ -753,6 +756,8 @@ const es = {
     rxtermsAttribution: "Las sugerencias de nombres de medicamentos incluyen datos de RxTerms, producido por la U.S. National Library of Medicine.",
     // Appearance
     sectionAppearance: "Apariencia",
+    tts: "Leer alarmas en voz alta",
+    ttsSubtitle: "Cuando suena la alarma, el teléfono dice el medicamento y la dosis",
     seniorMode: "Texto y botones grandes",
     seniorModeSubtitle: "Modo de visibilidad ampliada para las tarjetas de dosis",
     themeSystem: "Automático (sistema)",

--- a/src/i18n/pt.ts
+++ b/src/i18n/pt.ts
@@ -513,6 +513,9 @@ const pt: TranslationShape = {
   },
 
   // ─── Relatório PDF ────────────────────────────────────────────────────────
+  tts: {
+    alarmSpeech: "Hora de tomar {{name}}, {{dose}}.",
+  },
   backupCrypto: {
     setTitle: "Proteger com senha?",
     setSubtitle: "O arquivo fica criptografado: ninguém consegue ler sem a senha, nem mesmo onde você guardar (Drive, etc.).",
@@ -757,6 +760,8 @@ const pt: TranslationShape = {
     rxtermsAttribution: "As sugestões de nomes de medicamentos incluem dados do RxTerms, produzido pela U.S. National Library of Medicine.",
     // Appearance
     sectionAppearance: "Aparência",
+    tts: "Ler alarmes em voz alta",
+    ttsSubtitle: "Quando o alarme toca, o telefone fala o remédio e a dose",
     seniorMode: "Texto e botões grandes",
     seniorModeSubtitle: "Modo de visibilidade ampliada para os cartões de dose",
     themeSystem: "Automático (sistema)",

--- a/src/services/tts.ts
+++ b/src/services/tts.ts
@@ -1,0 +1,51 @@
+/**
+ * Spoken alarms (F4 — TTS): reads the dose reminder aloud when the alarm
+ * screen opens. Hands-free support for low-vision and elderly users.
+ * OPT-IN (default off) — noise discipline. Uses the device TTS engine via
+ * expo-speech; no audio leaves the device.
+ */
+import * as Speech from "expo-speech";
+import { storage } from "../storage";
+import { STORAGE_KEYS } from "../config";
+import i18n from "../i18n";
+
+export function isTtsEnabled(): boolean {
+  return storage.getString(STORAGE_KEYS.TTS_ENABLED) === "1";
+}
+
+export function setTtsEnabled(on: boolean): void {
+  storage.set(STORAGE_KEYS.TTS_ENABLED, on ? "1" : "0");
+}
+
+/** BCP-47 voice language for the current app language. */
+export function ttsLanguage(): string {
+  const lang = i18n.language ?? "es";
+  if (lang.startsWith("es")) return "es-ES";
+  if (lang.startsWith("pt")) return "pt-BR";
+  return "en-US";
+}
+
+/**
+ * Speaks a dose reminder ("Time to take X, dose Y"). Slightly slowed rate
+ * for intelligibility. Fire-and-forget; failures never affect the alarm.
+ */
+export function speakDoseReminder(medName: string, doseText: string): void {
+  if (!isTtsEnabled()) return;
+  try {
+    Speech.speak(i18n.t("tts.alarmSpeech", { name: medName, dose: doseText }) as string, {
+      language: ttsLanguage(),
+      rate: 0.9,
+    });
+  } catch {
+    /* TTS engine unavailable — the visual/audio alarm still covers the user */
+  }
+}
+
+/** Stops any ongoing speech (call when the alarm is confirmed/dismissed). */
+export function stopSpeaking(): void {
+  try {
+    Speech.stop();
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
## Qué hace

**Alarmas habladas (TTS)** — Fase 4, accesibilidad manos-libres para baja visión / mayores. **Opt-in** (apagado por defecto): Ajustes → Apariencia → "Leer alarmas en voz alta", al lado del modo senior.

- Cuando se abre la pantalla de alarma, el teléfono dice "Hora de tomar {{med}}, {{dosis}}" con el motor TTS del dispositivo (`expo-speech` — ningún audio sale del teléfono). Nunca en quick-actions de notificación.
- El habla se corta al confirmar/omitir/posponer o al salir de la pantalla.
- Voz según idioma de la app: es-ES / en-US / pt-BR; velocidad 0.9 para inteligibilidad. Un fallo del motor TTS jamás afecta la alarma.

## Validación

Jest **294/294** (4 tests nuevos), eslint limpio, tsc solo baseline, **BUILD SUCCESSFUL** con expo-speech autolinkeado. i18n ES/EN/PT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
