### PR TITLE
chore(release): bump 1.7.0 / versionCode 23

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Pill O-Clock",
     "slug": "pill-o-clock",
-    "version": "1.6.2",
+    "version": "1.7.0",
     "scheme": "pilloclock",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -31,7 +31,7 @@
     },
     "android": {
       "package": "com.pilloclock.app",
-      "versionCode": 22,
+      "versionCode": 23,
       "adaptiveIcon": {
         "backgroundColor": "#f0f6ff",
         "foregroundImage": "./assets/android-icon-foreground.png",


### PR DESCRIPTION
Bump a **1.7.0 (vc23)** para el build de prueba cerrada con las Fases 2-4 completas (PRs #88-#104). El versionCode de android/app/build.gradle se bumpea local (android/ persistente, no versionado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
