### PR TITLE
chore(release): vc24 — quitar permiso AD_ID mientras los ads están apagados

### DIFF
--- a/app.json
+++ b/app.json
@@ -31,7 +31,7 @@
     },
     "android": {
       "package": "com.pilloclock.app",
-      "versionCode": 23,
+      "versionCode": 24,
       "adaptiveIcon": {
         "backgroundColor": "#f0f6ff",
         "foregroundImage": "./assets/android-icon-foreground.png",

--- a/src/services/ads.ts
+++ b/src/services/ads.ts
@@ -12,6 +12,10 @@
  *  2. Play Console declarations are updated: "Anuncios" = Sí, "ID de
  *     publicidad" = Sí, Data safety + advertising category.
  *  3. Store listing copy no longer claims "no ads" (see store/play-store-*).
+ *  4. android/app/src/main/AndroidManifest.xml: REMOVE the
+ *     `com.google.android.gms.permission.AD_ID` tools:node="remove" line —
+ *     while ads are off we strip that permission so the honest "no ad ID"
+ *     Play declaration matches the bundle (Play rejects the mismatch).
  * Flipping this flag without (2)/(3) is a Play-policy violation.
  *
  * DEP PIN: react-native-google-mobile-ads is pinned to ^15.7.0


### PR DESCRIPTION
Play rechazó el release vc23: la lib de AdMob mete el permiso **AD_ID** en el manifest, pero nuestra declaración honesta dice "no usa advertising ID" (los ads están compilados pero apagados). Hasta el flip de ads: `tools:node="remove"` en el manifest persistente + paso 4 nuevo en el checklist de `ads.ts` para revertirlo. vc23 quedó consumido; mismo 1.7.0 como **vc24**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
