### PR TITLE
docs(store): reemplazar claims absolutos de privacidad por lenguaje preciso

### DIFF
--- a/store/play-store-en.txt
+++ b/store/play-store-en.txt
@@ -7,13 +7,13 @@
 Pill O-Clock: Pill Reminder
 
 ── SHORT DESCRIPTION (max 80 characters) ───────────────
-Medication alarm & health diary. No account required — 100% free & private.
+Medication alarm & health diary. No account required — free & private.
 
 ── FULL DESCRIPTION (max 4000 characters) ──────────────
 
 💊 Pill O-Clock — The medication alarm that actually rings
 
-Never miss a dose again. Pill O-Clock is a complete personal health assistant: it fires a real alarm sound when it's time to take your medication, tracks every dose you take (or skip), monitors your health measurements with trend charts, and records how you feel each day — all stored privately on your phone. No account. No subscription. No data leaving your device. Ever.
+Never miss a dose again. Pill O-Clock is a complete personal health assistant: it fires a real alarm sound when it's time to take your medication, tracks every dose you take (or skip), monitors your health measurements with trend charts, and records how you feel each day — all stored privately on your phone. No account. No subscription. Your health data never leaves your device.
 
 ▸ ALARMS THAT ACTUALLY RING
 Most reminder apps send a silent notification that's easy to ignore. Pill O-Clock rings a full alarm sound that repeats every 5 minutes until you respond. Take the dose, snooze for 15 minutes, or skip — all directly from the notification or lock screen, without opening the app.
@@ -43,7 +43,7 @@ Monthly view that groups your doses by day and status — pending, taken, skippe
 Keep all your upcoming and past medical appointments organized: doctor name, location with map pin, date/time, notes, and a configurable reminder (1 hour, 2 hours, or 1 day before).
 
 ▸ YOUR DATA IS YOURS — ALWAYS
-Everything is stored in a private local database on your device. Nothing is ever sent to external servers. No account, no cloud sync, no analytics, no ads. Export a full backup (medications, history, appointments, health data, and diary) at any time and restore it if you switch phones.
+Your health data — medications, history, measurements, and diary — lives in a private local database and never leaves your device. The only exceptions: technical crash diagnostics (which never include your health data) and, if you add a location to an appointment, the map lookup. No account, no cloud sync, no usage analytics, no ads. Export a full backup (medications, history, appointments, health data, and diary) at any time and restore it if you switch phones.
 
 ▸ SPANISH & ENGLISH
 The app automatically detects your device language. Spanish and English are both fully supported, and you can switch languages manually from Settings at any time.
@@ -100,10 +100,12 @@ privacy@pilloclock.app
 https://giulianotaliano.github.io/pill-o-clock/privacy-policy.html
 
 ── DATA SAFETY FORM (answers) ───────────────────────────
-Does the app collect data?           → No (all data is local-only)
-Does the app share data?             → No
-Can users request data deletion?     → Yes (Settings → Delete all data)
-Is data encrypted in transit?        → N/A (no data is transmitted)
+(corrected & submitted to Play 2026-07-22 — see audit C6/H14/H15)
+Does the app collect/share data?     → Yes — Location (precise; appointment map picker → Google Maps)
+                                       and Crash logs + Diagnostics (Sentry).
+                                       All other health data stays on-device only.
+Can users request data deletion?     → No request mechanism (data is local; removed on uninstall)
+Is data encrypted in transit?        → Yes (HTTPS to Google / Sentry)
 Does it follow Families guidelines?  → No
 
 ── FEATURE GRAPHIC SUGGESTED COPY ──────────────────────

--- a/store/play-store-es.txt
+++ b/store/play-store-es.txt
@@ -7,25 +7,25 @@
 Pill O-Clock: Pastillero
 
 ── DESCRIPCIÓN BREVE (max 80 caracteres) ───────────────
-Alarma de medicamentos y diario de salud. Sin cuenta — gratis y 100% privado.
+Alarma de medicamentos y diario de salud. Sin cuenta — gratis y privado.
 
 ── DESCRIPCIÓN COMPLETA (max 4000 caracteres) ──────────
 
 💊 Pill O-Clock — La alarma de medicamentos que realmente suena
 
-Nunca más olvidés una dosis. Pill O-Clock es tu asistente personal de salud completo: hace sonar una alarma real cuando es hora de tomar tu medicamento, registra cada dosis que tomás (o no), hace seguimiento de tus mediciones con gráficos de tendencia, y te permite anotar cómo te sentís cada día — todo guardado de forma privada en tu teléfono. Sin cuenta. Sin suscripción. Sin que tus datos salgan de tu dispositivo. Nunca.
+Nunca más olvidés una dosis. Pill O-Clock es tu asistente personal de salud completo: hace sonar una alarma real cuando es hora de tomar tu medicamento, registra cada dosis que tomás (o no), y sigue tus mediciones de salud y cómo te sentís cada día — todo guardado de forma privada en tu teléfono. Sin cuenta. Sin suscripción. Tus datos de salud nunca salen de tu dispositivo.
 
 ▸ ALARMAS QUE REALMENTE SUENAN
 La mayoría de las apps de recordatorio envían una notificación silenciosa fácil de ignorar. Pill O-Clock hace sonar una alarma completa que se repite cada 5 minutos hasta que respondés. Tomá la dosis, posponé 15 minutos u omití — todo directamente desde la notificación o la pantalla de bloqueo, sin abrir la app.
 
 ▸ GESTIÓN COMPLETA DE MEDICAMENTOS
-Agregá cualquier medicamento con su nombre, dosis (mg, ml, gotas, comprimidos, cápsulas…), categoría, instrucciones especiales, color, período de tratamiento y una foto opcional del envase. Configurá una o múltiples alarmas por día, solo algunos días de la semana, o todos los días — o marcálo como a demanda (PRN) para registrar tomas no programadas como analgésicos o antihistamínicos. Controlá el stock actual y recibí alertas automáticas de stock bajo antes de quedarte sin dosis.
+Agregá cualquier medicamento con su nombre, dosis (mg, ml, gotas, comprimidos, cápsulas…), categoría, instrucciones especiales, color, período de tratamiento y una foto opcional del envase. Configurá una o varias alarmas por día, ciertos días de la semana o todos los días — o marcálo como a demanda (PRN) para tomas no programadas como analgésicos. Controlá el stock y recibí alertas automáticas antes de quedarte sin dosis.
 
 ▸ MEDICIONES DE SALUD
-Registrá presión arterial (sistólica/diastólica), glucemia, peso, SpO₂ y frecuencia cardíaca. Cada métrica muestra el último valor, una mini gráfica y un gráfico de tendencia completo para detectar patrones a lo largo del tiempo. Configurá un recordatorio diario opcional para medir.
+Registrá presión arterial (sistólica/diastólica), glucemia, peso, SpO₂ y frecuencia cardíaca. Cada métrica muestra el último valor, una mini gráfica y un gráfico de tendencia completo para detectar patrones. Configurá un recordatorio diario opcional para medir.
 
 ▸ DIARIO DE BIENESTAR DIARIO
-Registrá tu estado de ánimo en una escala de 5 niveles y hacé seguimiento de síntomas cada día — dolor de cabeza, náuseas, fatiga, mareos, dolor de estómago, ansiedad, insomnio y más. Las entradas pasadas son editables en cualquier momento. Correlacioná cómo te sentís con tu historial de medicación de un vistazo.
+Registrá tu estado de ánimo en una escala de 5 niveles y hacé seguimiento de síntomas cada día — dolor de cabeza, náuseas, fatiga, mareos, dolor de estómago, ansiedad, insomnio y más. Correlacioná cómo te sentís con tu historial de medicación de un vistazo.
 
 ▸ REPORTE PDF PARA TU MÉDICO
 Generá un informe completo de salud en PDF con un toque — medicamentos activos, historial de dosis de los últimos 30 días, mediciones y diario de bienestar — listo para compartir con tu médico o especialista en tu próxima consulta.
@@ -34,19 +34,19 @@ Generá un informe completo de salud en PDF con un toque — medicamentos activo
 Colocá un widget 2×1 en tu pantalla de inicio para ver tu próxima dosis pendiente y marcarla como tomada — sin abrir la app.
 
 ▸ RACHA DE ADHERENCIA E HISTORIAL
-Un chip de llama en la pantalla principal muestra tus días consecutivos de adherencia completa. La pestaña Historial muestra dosis tomadas, omitidas y no tomadas con un porcentaje de adherencia claro. Activá la vista mensual para ver un mapa de calor de adherencia — días verdes, amarillos y rojos — de todo el mes de un vistazo.
+Un chip de llama en la pantalla principal muestra tus días consecutivos de adherencia completa. La pestaña Historial muestra dosis tomadas, omitidas y no tomadas con un porcentaje de adherencia claro. Activá la vista mensual para ver un mapa de calor de adherencia de todo el mes.
 
 ▸ CALENDARIO VISUAL
-Vista mensual que agrupa tus dosis por día y estado — pendientes, tomadas, omitidas y no tomadas — para identificar al instante los días con incidencias y mantenerte en control.
+Vista mensual que agrupa tus dosis por día y estado para identificar al instante los días con incidencias.
 
 ▸ CITAS MÉDICAS
 Organizá todas tus citas médicas próximas y pasadas: nombre del médico, ubicación con pin en el mapa, fecha/hora, notas y recordatorio configurable (1 hora, 2 horas o 1 día antes).
 
 ▸ TUS DATOS SON TUYOS — SIEMPRE
-Todo se almacena en una base de datos local privada en tu dispositivo. Nada se envía a servidores externos. Sin cuenta, sin sincronización en la nube, sin analíticas, sin anuncios. Exportá una copia de seguridad completa (medicamentos, historial, turnos, mediciones de salud y diario) en cualquier momento y restaurala si cambiás de teléfono.
+Tus datos de salud — medicamentos, historial, mediciones y diario — viven en una base de datos local privada y nunca salen de tu dispositivo. Las únicas excepciones: diagnósticos técnicos de fallos (que jamás incluyen tus datos de salud) y, si agregás la ubicación de una cita, la consulta al mapa. Sin cuenta, sin sincronización en la nube, sin analíticas de uso, sin anuncios. Exportá una copia de seguridad completa en cualquier momento y restaurala si cambiás de teléfono.
 
 ▸ DISPONIBLE EN ESPAÑOL E INGLÉS
-La app detecta automáticamente el idioma de tu dispositivo. Español e inglés tienen soporte completo, y podés cambiar el idioma manualmente desde Ajustes en cualquier momento.
+La app detecta el idioma de tu dispositivo — español e inglés con soporte completo — y podés cambiarlo desde Ajustes cuando quieras.
 
 ▸ MODO OSCURO Y DISEÑO LIMPIO
 Sigue automáticamente el tema claro/oscuro del sistema. Tipografía clara y legible con indicadores de estado por colores para un uso rápido y fácil.
@@ -100,10 +100,12 @@ privacy@pilloclock.app
 https://giulianotaliano.github.io/pill-o-clock/privacy-policy.html
 
 ── DATA SAFETY (respuestas para el formulario) ──────────
-¿Recopila datos?          → No (todos los datos son locales)
-¿Comparte datos?          → No
-¿Permite eliminar datos?  → Sí (Ajustes → Borrar todos los datos)
-¿Cifrado en tránsito?     → No aplica (no hay tránsito de datos)
+(corregido y enviado a Play el 2026-07-22 — ver auditoría C6/H14/H15)
+¿Recopila / comparte datos?  → Sí — Ubicación (precisa; selector de mapa de citas → Google Maps)
+                               y Registros de fallos + Diagnósticos (Sentry).
+                               El resto de los datos de salud queda solo en el dispositivo.
+¿Permite eliminar datos?     → Sin mecanismo de solicitud (datos locales; se eliminan al desinstalar)
+¿Cifrado en tránsito?        → Sí (HTTPS hacia Google / Sentry)
 ¿Sigue pautas de datos de familia?  → No
 
 ── COPIA SUGERIDA PARA EL FEATURE GRAPHIC ───────────────


### PR DESCRIPTION
## Resumen

La ficha de Play afirmaba en absoluto que ningún dato sale del dispositivo (ES: "Nada se envía a servidores externos"; EN: "No data leaving your device. Ever."). Es inexacto: los builds de producción envían diagnósticos de fallos a Sentry (`app/_layout.tsx`) y el selector de ubicación de citas envía el texto buscado + coordenadas a Google Maps/Places (`components/LocationPickerModal.tsx`). La honestidad precisa era el gap #1 del battlecard competitivo.

## Cambios

- **Descripción completa (ES/EN):** los datos de salud nunca salen del dispositivo, con las dos únicas excepciones nombradas explícitamente — diagnósticos técnicos de fallos (que jamás incluyen datos de salud) y la consulta al mapa al agregar la ubicación de una cita. Se evitó llamar "anónimos" a los reportes de Sentry (incluyen estado del dispositivo/app y la política de privacidad no reclama anonimato): habría sido otro claim impreciso.
- **Descripción breve (ES/EN):** se quita el absoluto "100%" ("gratis y privado" / "free & private").
- **Bloques Data safety en ambos txt:** estaban desactualizados (decían "no recopila / no comparte / no hay tránsito"); ahora reflejan la declaración corregida y enviada a Play el 2026-07-22 (auditoría C6/H14/H15), igual que `store/submission-checklist.txt` (PR #80).
- **Recorte de la descripción ES a 3982 caracteres:** en `main` ya estaba en **4198**, por encima del límite de 4000 de la consola, y con la corrección subía a 4395. Podas solo de verbosidad — ninguna sección eliminada, voseo y tono intactos. La EN quedó en 3958 sin recortes.

## Verificación

- Breve: ES 72 / EN 70 (límite 80). Completa: ES 3982 / EN 3958 (límite 4000).
- `README.md` y `docs/privacy-policy.html` ya describen ambas excepciones con precisión — sin cambios.
- Grep del repo: el absoluto no aparece en ningún otro archivo (la mención en `docs/auditoria-2026-07.md` es el registro del hallazgo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
