### PR TITLE
docs(store): quitar palabra de precio de las descripciones breves

### DIFF
--- a/store/play-store-en.txt
+++ b/store/play-store-en.txt
@@ -7,7 +7,7 @@
 Pill O-Clock: Pill Reminder
 
 ── SHORT DESCRIPTION (max 80 characters) ───────────────
-Medication alarm & health diary. No account required — free & private.
+Medication alarm & health diary. No account required — private.
 
 ── FULL DESCRIPTION (max 4000 characters) ──────────────
 

--- a/store/play-store-es.txt
+++ b/store/play-store-es.txt
@@ -7,7 +7,7 @@
 Pill O-Clock: Pastillero
 
 ── DESCRIPCIÓN BREVE (max 80 caracteres) ───────────────
-Alarma de medicamentos y diario de salud. Sin cuenta — gratis y privado.
+Alarma de medicamentos y diario de salud. Sin cuenta y privado.
 
 ── DESCRIPCIÓN COMPLETA (max 4000 caracteres) ──────────
 


### PR DESCRIPTION
## Resumen

Al pegar en Play Console las fichas actualizadas del PR #108, la consola marcó las descripciones breves por los lineamientos de metadatos ("No incluyas palabras clave que indiquen precios o promociones") por culpa de "gratis"/"free", con la advertencia de que la app podría no promocionarse en Google Play.

## Cambios

- **ES:** "Sin cuenta — gratis y privado." → "Sin cuenta y privado." (63/80)
- **EN:** "No account required — free & private." → "No account required — private." (63/80)

## Estado

Ya aplicado y guardado en Play Console (es-419 y en-GB, 2026-07-23) como cambio pendiente — este PR solo sincroniza los archivos del repo con lo que quedó en la consola. La advertencia de precio dejó de aparecer al guardar. Que la app sea gratis sigue dicho donde corresponde: en Pricing & distribution (Free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
