### PR TITLE
fix(types): alinear useForm con el Resolver input/output de zodResolver

### DIFF
--- a/components/MedicationForm.tsx
+++ b/components/MedicationForm.tsx
@@ -27,7 +27,7 @@ import * as Haptics from "expo-haptics";
 import { useToast } from "../src/context/ToastContext";
 import { useForm, Controller, useFieldArray } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { medicationFormSchema, type MedicationFormData } from "../src/schemas/medication";
+import { medicationFormSchema, type MedicationFormData, type MedicationFormInput } from "../src/schemas/medication";
 import { searchDrugs, type DrugSuggestion } from "../src/services/drugDb";
 import { BarcodeScannerModal } from "./BarcodeScannerModal";
 import { parseRegimen, buildRegimenJson, type Regimen } from "../src/services/regimen";
@@ -356,7 +356,7 @@ export function MedicationForm({
     ? parseRegimen({ regimen: initialValues.regimen })
     : null;
 
-  const { control, handleSubmit: rhfHandleSubmit, watch, setValue, trigger, formState: { errors } } = useForm<MedicationFormData>({
+  const { control, handleSubmit: rhfHandleSubmit, watch, setValue, trigger, formState: { errors } } = useForm<MedicationFormInput, unknown, MedicationFormData>({
     resolver: zodResolver(medicationFormSchema),
     defaultValues: {
       name: initialValues?.name ?? "",

--- a/src/schemas/medication.ts
+++ b/src/schemas/medication.ts
@@ -101,4 +101,7 @@ export const medicationFormSchema = z
     }
   });
 
-export type MedicationFormData = z.infer<typeof medicationFormSchema>;
+// Input vs output diverge because of the .default() fields: they are optional
+// before parsing and guaranteed after. useForm needs both sides (rhf >= 7.55).
+export type MedicationFormInput = z.input<typeof medicationFormSchema>;
+export type MedicationFormData = z.output<typeof medicationFormSchema>;


### PR DESCRIPTION
## Resumen

Tras el churn de package-lock de PR #87 (`npm install react-native-google-mobile-ads`), quedaron react-hook-form 7.71.2 + @hookform/resolvers 5.2.2 + zod 4.3.6, y `npx tsc --noEmit` empezó a fallar en `components/MedicationForm.tsx` (TS2322 en `resolver:` y TS2345 en las dos llamadas a `rhfHandleSubmit`).

**Causa raíz:** desde resolvers 5.x / rhf 7.55+, `zodResolver` devuelve `Resolver<Input, Context, Output>` distinguiendo `z.input` de `z.output`. Como `medicationFormSchema` tiene campos con `.default()` (`notes`, `stockQtyStr`, `regimenType`, `taperSteps`, `isInjectable`, etc.), input y output divergen: esos campos son opcionales antes de parsear y obligatorios después. `useForm<MedicationFormData>` (solo output) esperaba `Resolver<Output, ..., Output>` → mismatch. Con resolvers 3.x/4.x (pre-#87) todo se tipaba con el output, por eso compilaba antes.

**Fix (solo tipos, cero cambios de runtime):**
- `src/schemas/medication.ts`: se exporta `MedicationFormInput = z.input<...>` junto a `MedicationFormData = z.output<...>` (idéntico al `z.infer` anterior).
- `components/MedicationForm.tsx`: `useForm<MedicationFormInput, unknown, MedicationFormData>(...)` — el patrón documentado por react-hook-form ≥ 7.55 para esquemas con defaults/transforms. `handleSubmit` sigue entregando el tipo output a `handleFormSubmit`.

No se pinnearon ni cambiaron versiones: las instaladas son coherentes entre sí; el problema era solo la instanciación de genéricos.

## Validación

- `npx tsc --noEmit`: desaparecen los 3 errores de `MedicationForm.tsx`; sin errores nuevos.
- `npx jest`: 27 suites / 294 tests OK.

## Preexistente, fuera de alcance (ya estaba antes de este PR)

`tsc --noEmit` todavía reporta errores sin relación con el form: globals de Jest en `__tests__/**` y `jest.setup.ts` (falta `@types/jest`), `app.config.ts` (ExpoConfig), `app/medication/[id].tsx` (width como string) y `src/services/pdfReport.ts` (TFunction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
