### PR TITLE
fix(backup): rebuild appointment reminders on import instead of trusting device-local ids

### DIFF
--- a/__tests__/backup.test.ts
+++ b/__tests__/backup.test.ts
@@ -10,12 +10,19 @@
  *  - The exported JSON carries every Medication field as-is.
  *  - A Medication with ALL optional fields set survives export→import.
  *  - renewalNotifIds is the one intentional exception (device-local OS ids).
+ *  - Appointment.notificationId is stripped the same way, and import
+ *    reschedules reminders on the importing device instead.
  *  - Legacy backups without the newer optional fields still import.
  */
 
+/* eslint-disable import/namespace -- the eslint resolver picks
+   db/database.web.ts (an intentionally partial stub), so `db.*` members that
+   only exist in the native db/database.ts are false-positive "not found".
+   Jest itself resolves the native module. */
+
 import { exportBackup, importBackup } from "../src/services/backup";
 import { makeMedication } from "./factories";
-import type { Medication } from "../src/types";
+import type { Appointment, Medication } from "../src/types";
 
 jest.mock("expo-file-system", () => ({
   File: jest.fn(),
@@ -55,12 +62,19 @@ jest.mock("../src/db/database", () => ({
   upsertDailyCheckin: jest.fn(),
   insertProfile: jest.fn(),
   insertAllergy: jest.fn(),
+  updateAppointment: jest.fn(),
+}));
+
+jest.mock("../src/services/notifications", () => ({
+  scheduleAppointmentNotification: jest.fn(),
+  cancelAppointmentNotification: jest.fn(),
 }));
 
 import * as DocumentPicker from "expo-document-picker";
 import { File } from "expo-file-system";
 import { StorageAccessFramework } from "expo-file-system/src/legacy";
 import * as db from "../src/db/database";
+import * as notifications from "../src/services/notifications";
 
 /**
  * Every optional Medication field set. `Required<>` makes this fail to compile
@@ -88,12 +102,34 @@ const FULL_MED: Required<Medication> = {
   archiveReason: "doctor",
 };
 
+/**
+ * Every optional Appointment field set — same compile-time guard as FULL_MED:
+ * a new Appointment field breaks this until appointmentSchema is revisited.
+ */
+const FULL_APPT: Required<Appointment> = {
+  id: "appt-1",
+  title: "Cardiología",
+  doctor: "Dra. Pérez",
+  location: "Hospital Italiano",
+  locationCoords: { latitude: -34.6037, longitude: -58.3816 },
+  notes: "llevar estudios previos",
+  date: "2099-05-20",
+  time: "09:30",
+  reminderMinutes: 60,
+  notificationId: "old-device-notif-1|old-device-notif-2",
+  createdAt: "2026-07-01T00:00:00.000Z",
+  profileId: "profile-2",
+};
+
+/** FULL_APPT as import must deliver it: without the exporting device's id. */
+const { notificationId: _oldDeviceId, ...IMPORTED_APPT } = FULL_APPT;
+
 /** Runs exportBackup with the given entities and returns the JSON it wrote. */
-async function runExport(medications: Medication[]): Promise<string> {
+async function runExport(medications: Medication[], appointments: Appointment[] = []): Promise<string> {
   jest.mocked(db.getMedications).mockResolvedValue(medications);
   jest.mocked(db.getAllSchedules).mockResolvedValue([]);
   jest.mocked(db.getAllDoseLogs).mockResolvedValue([]);
-  jest.mocked(db.getAppointments).mockResolvedValue([]);
+  jest.mocked(db.getAppointments).mockResolvedValue(appointments);
   jest.mocked(db.getAllAppointmentDocuments).mockResolvedValue([]);
   jest.mocked(db.getHealthMeasurements).mockResolvedValue([]);
   jest.mocked(db.getDailyCheckins).mockResolvedValue([]);
@@ -123,8 +159,14 @@ type AnyMock = {
   mockResolvedValue: (value: unknown) => void;
 };
 
-/** Runs importBackup("replace") against the given backup JSON. */
-async function runImport(json: string): Promise<{ count: number }> {
+/** Runs importBackup against the given backup JSON. `existingAppointments`
+ *  is what the device already holds when the import starts (stale-reminder
+ *  cancellation on "replace"). */
+async function runImport(
+  json: string,
+  opts: { mode?: "replace" | "merge"; existingAppointments?: Appointment[] } = {}
+): Promise<{ count: number }> {
+  const { mode = "replace", existingAppointments = [] } = opts;
   jest.mocked(DocumentPicker.getDocumentAsync).mockResolvedValue({
     canceled: false,
     assets: [{ uri: "file:///picked.json" }],
@@ -136,7 +178,8 @@ async function runImport(json: string): Promise<{ count: number }> {
   (db.getDb as unknown as AnyMock).mockResolvedValue({
     withTransactionAsync: (fn: () => Promise<void>) => fn(),
   });
-  return importBackup("replace");
+  jest.mocked(db.getAppointments).mockResolvedValue(existingAppointments);
+  return importBackup(mode);
 }
 
 beforeEach(() => {
@@ -183,5 +226,71 @@ describe("backup export→import round-trip", () => {
     const { count } = await runImport(legacy);
     expect(count).toBe(1);
     expect(jest.mocked(db.insertMedication).mock.calls[0][0]).toEqual(makeMedication());
+  });
+});
+
+describe("appointment reminders across export→import", () => {
+  it("exports every Appointment field as-is", async () => {
+    const written = await runExport([], [FULL_APPT]);
+    const parsed = JSON.parse(written);
+    expect(parsed.data.appointments[0]).toEqual(FULL_APPT);
+  });
+
+  it("strips the exporting device's notificationId and reschedules on this device", async () => {
+    const written = await runExport([], [FULL_APPT]);
+    jest
+      .mocked(notifications.scheduleAppointmentNotification)
+      .mockResolvedValue("fresh-notif-1|fresh-notif-2");
+
+    await runImport(written);
+
+    const inserted = jest.mocked(db.insertAppointment).mock.calls[0][0];
+    expect(inserted).toEqual(IMPORTED_APPT);
+    expect("notificationId" in inserted).toBe(false);
+
+    // The reminder is rebuilt here, and the fresh ids are persisted so a later
+    // edit/delete can cancel them.
+    expect(notifications.scheduleAppointmentNotification).toHaveBeenCalledWith(IMPORTED_APPT);
+    expect(db.updateAppointment).toHaveBeenCalledWith({
+      ...IMPORTED_APPT,
+      notificationId: "fresh-notif-1|fresh-notif-2",
+    });
+  });
+
+  it("persists nothing when no reminder could be scheduled (past date / web)", async () => {
+    const written = await runExport([], [FULL_APPT]);
+    jest.mocked(notifications.scheduleAppointmentNotification).mockResolvedValue(undefined);
+
+    await runImport(written);
+
+    expect(db.updateAppointment).not.toHaveBeenCalled();
+  });
+
+  it("replace-import cancels the reminders queued for the wiped appointments", async () => {
+    const written = await runExport([], [FULL_APPT]);
+    const onDevice: Appointment[] = [
+      { ...FULL_APPT, id: "appt-old", notificationId: "stale-1|stale-2" },
+      { ...IMPORTED_APPT, id: "appt-never-scheduled" }, // no id → nothing to cancel
+    ];
+
+    await runImport(written, { existingAppointments: onDevice });
+
+    expect(notifications.cancelAppointmentNotification).toHaveBeenCalledTimes(1);
+    expect(notifications.cancelAppointmentNotification).toHaveBeenCalledWith("stale-1|stale-2");
+  });
+
+  it("merge-import neither cancels existing reminders nor reschedules duplicates", async () => {
+    const written = await runExport([], [FULL_APPT]);
+    // Same id already on the device → insertAppointment rejects (duplicate).
+    jest.mocked(db.insertAppointment).mockRejectedValueOnce(new Error("UNIQUE constraint"));
+
+    await runImport(written, {
+      mode: "merge",
+      existingAppointments: [{ ...FULL_APPT, notificationId: "live-1" }],
+    });
+
+    expect(notifications.cancelAppointmentNotification).not.toHaveBeenCalled();
+    expect(notifications.scheduleAppointmentNotification).not.toHaveBeenCalled();
+    expect(db.updateAppointment).not.toHaveBeenCalled();
   });
 });

--- a/src/services/backup.ts
+++ b/src/services/backup.ts
@@ -25,7 +25,9 @@ import {
   insertProfile,
   getAllAllergies,
   insertAllergy,
+  updateAppointment,
 } from "../db/database";
+import { scheduleAppointmentNotification, cancelAppointmentNotification } from "./notifications";
 
 // ─── Zod schemas ───────────────────────────────────────────────────────────
 
@@ -110,7 +112,11 @@ const appointmentSchema = z.object({
   date: z.string(),
   time: z.string().optional(),
   reminderMinutes: z.number().optional(),
-  notificationId: z.string().optional(),
+  // notificationId is deliberately absent (same reason as renewalNotifIds
+  // above): the id references a notification queued on the exporting device,
+  // so a restored install would believe a reminder is scheduled when nothing
+  // is. zod strips the key on parse; importBackup reschedules reminders for
+  // the appointments it inserts.
   createdAt: z.string(),
   profileId: z.string().optional(),
 });
@@ -280,6 +286,13 @@ export async function importBackup(
     const backup = parsed.data;
     const db = await getDb();
 
+    // "replace" wipes these rows below, but their reminders stay queued in the
+    // OS and would fire for appointments that no longer exist. Collect the ids
+    // now; cancel only after the transaction commits (a failed import must not
+    // cancel live reminders).
+    const staleAppointments = mode === "replace" ? await getAppointments() : [];
+    const importedAppointments: Appointment[] = [];
+
     await db.withTransactionAsync(async () => {
     if (mode === "replace") {
       await clearAllData();
@@ -331,6 +344,9 @@ export async function importBackup(
     for (const appt of backup.data.appointments) {
       try {
         await insertAppointment(appt as Appointment);
+        // Only appointments actually inserted get reminders rebuilt below —
+        // a merge-mode duplicate keeps the existing row's live reminder.
+        importedAppointments.push(appt as Appointment);
       } catch {
         // Skip duplicates on merge.
       }
@@ -360,6 +376,22 @@ export async function importBackup(
       }
     }
     });
+
+    for (const stale of staleAppointments) {
+      if (stale.notificationId) await cancelAppointmentNotification(stale.notificationId);
+    }
+
+    // Backups never carry notificationId (see appointmentSchema): rebuild each
+    // restored appointment's reminders on THIS device and persist the fresh
+    // ids. scheduleAppointmentNotification itself skips past dates and web.
+    for (const appt of importedAppointments) {
+      try {
+        const notificationId = await scheduleAppointmentNotification(appt);
+        if (notificationId) await updateAppointment({ ...appt, notificationId });
+      } catch {
+        // Best-effort: the appointment data itself is already committed.
+      }
+    }
 
     return { count: backup.data.medications.length };
   } finally {


### PR DESCRIPTION
appointmentSchema round-tripped `notificationId`, but OS notification ids only exist on the device that scheduled them: after a restore on a new install the app believed a reminder was queued and nothing ever fired (same class as audit H5, and the `renewalNotifIds` strip merged in #109).

- `appointmentSchema` drops `notificationId`; zod strips it on import.
- `importBackup` reschedules reminders for every appointment it actually inserts and persists the fresh ids (merge-mode duplicates keep the existing row's live reminder; past dates and web are skipped by `scheduleAppointmentNotification` itself).
- Replace-mode imports now cancel the reminders queued for the wiped appointments, after the transaction commits, so ghosts don't fire.
- `backup.test.ts`: `Required<Appointment>` compile-time guard + 5 round-trip cases; file-level `import/namespace` disable (the resolver picks the partial `database.web.ts` stub — false positives; jest resolves the native module).

Validación: 302/302 tests, `tsc --noEmit` solo con el baseline pre-existente, `eslint` limpio en los archivos tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)