### PR TITLE
feat(ads): activar banners con IDs reales de AdMob

### DIFF
--- a/app.json
+++ b/app.json
@@ -86,7 +86,7 @@
       [
         "react-native-google-mobile-ads",
         {
-          "androidAppId": "ca-app-pub-3940256099942544~3347511713",
+          "androidAppId": "ca-app-pub-6639820412660854~4363189908",
           "iosAppId": "ca-app-pub-3940256099942544~1458002511"
         }
       ],

--- a/app/(tabs)/health.tsx
+++ b/app/(tabs)/health.tsx
@@ -873,7 +873,7 @@ export default function HealthScreen() {
         existing={editCheckin}
       />
       {/* Monetization slot (renders null while ads are disabled — see ads.ts) */}
-      <AdBanner />
+      <AdBanner screen="health" />
     </SafeAreaView>
   );
 }

--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -455,7 +455,7 @@ export default function HistoryScreen() {
         ListFooterComponent={<View className="h-6" />}
       />
       {/* Monetization slot (renders null while ads are disabled — see ads.ts) */}
-      <AdBanner />
+      <AdBanner screen="history" />
     </SafeAreaView>
   );
 }

--- a/components/AdBanner.tsx
+++ b/components/AdBanner.tsx
@@ -5,9 +5,9 @@
  */
 import { useEffect, useState } from "react";
 import { View } from "react-native";
-import { adsEnabled, getBannerUnitId } from "../src/services/ads";
+import { adsEnabled, getBannerUnitId, type BannerScreen } from "../src/services/ads";
 
-export function AdBanner() {
+export function AdBanner({ screen = "history" }: { screen?: BannerScreen } = {}) {
   const [ready, setReady] = useState(false);
   const [failed, setFailed] = useState(false);
 
@@ -33,7 +33,7 @@ export function AdBanner() {
   return (
     <View className="items-center">
       <BannerAd
-        unitId={getBannerUnitId()}
+        unitId={getBannerUnitId(screen)}
         size={BannerAdSize.ANCHORED_ADAPTIVE_BANNER}
         requestOptions={{ requestNonPersonalizedAdsOnly: true }}
         onAdFailedToLoad={() => setFailed(true)}

--- a/src/services/ads.ts
+++ b/src/services/ads.ts
@@ -6,19 +6,18 @@
  *    screen, the Today list, or the medication form. No interstitials, ever.
  *  - Non-personalized ad requests only (privacy posture).
  *
- * MASTER SWITCH: ADS_ENABLED stays false until ALL of the following happen —
- *  1. A real AdMob account exists and real app/unit IDs replace the Google
- *     TEST IDs below (app IDs live in app.json + android AndroidManifest).
- *  2. Play Console declarations are updated: "Anuncios" = Sí, "ID de
- *     publicidad" = Sí, Data safety + advertising category.
- *  3. Store listing copy no longer claims "no ads" (see store/play-store-*).
- *  4. android/app/src/main/AndroidManifest.xml: REMOVE the four
- *     tools:node="remove" lines (`com.google.android.gms.permission.AD_ID`
- *     and the three `android.permission.ACCESS_ADSERVICES_*`) — while ads
- *     are off we strip every ad-identifier permission the AdMob lib merges
- *     in so the honest "no ad ID" Play declaration matches the bundle
- *     (Play rejected the vc23 release over exactly this mismatch).
- * Flipping this flag without (2)/(3) is a Play-policy violation.
+ * FLIPPED ON 2026-07-23 (AdMob account giuliano.taliano1@gmail.com):
+ *  ✓ Real app/unit IDs below and in app.json + android AndroidManifest.
+ *  ✓ The four tools:node="remove" ad-permission strips removed from the
+ *    persistent manifest (AD_ID + ACCESS_ADSERVICES_* are declared again).
+ *  ✓ Store listing copy no longer claims "no ads".
+ *  ✓ app-ads.txt published at giulianotaliano.github.io/app-ads.txt.
+ *  ⚠ REMAINING (manual, at the org-account resubmission): Play Console
+ *    declarations "Anuncios" = Sí and "ID de publicidad" = Sí + Data
+ *    safety advertising entries. Shipping a release before those are set
+ *    is a Play-policy violation.
+ * Dev builds keep Google's TEST ids (clicking real ads in dev violates
+ * AdMob policy); release builds use the real units.
  *
  * DEP PIN: react-native-google-mobile-ads is pinned to ^15.7.0
  * (play-services-ads 24.5.0). Do NOT bump to 16.x until the project's Kotlin
@@ -27,17 +26,27 @@
  */
 import { Platform } from "react-native";
 
-export const ADS_ENABLED = false;
+export const ADS_ENABLED = true;
 
-/** Google's official test banner unit ids — safe to ship, never monetize. */
+/** Google's official test banner unit ids — used in dev builds only. */
 const TEST_BANNER_ANDROID = "ca-app-pub-3940256099942544/9214589741";
 const TEST_BANNER_IOS = "ca-app-pub-3940256099942544/2435281174";
+
+/** Real units (AdMob app Pill O-Clock, Android). One per surface so revenue
+ *  and fill can be compared per screen in AdMob reporting. */
+const REAL_BANNER_HISTORY = "ca-app-pub-6639820412660854/2454231920";
+const REAL_BANNER_HEALTH = "ca-app-pub-6639820412660854/4331400319";
+
+export type BannerScreen = "history" | "health";
 
 export function adsEnabled(): boolean {
   return ADS_ENABLED && Platform.OS !== "web";
 }
 
-export function getBannerUnitId(): string {
-  // Swap for real unit ids at launch (keep test ids for dev builds).
-  return Platform.OS === "ios" ? TEST_BANNER_IOS : TEST_BANNER_ANDROID;
+export function getBannerUnitId(screen: BannerScreen = "history"): string {
+  if (__DEV__ || Platform.OS === "ios") {
+    // No iOS app registered in AdMob yet — test id keeps iOS dev builds safe.
+    return Platform.OS === "ios" ? TEST_BANNER_IOS : TEST_BANNER_ANDROID;
+  }
+  return screen === "health" ? REAL_BANNER_HEALTH : REAL_BANNER_HISTORY;
 }

--- a/store/play-store-en.txt
+++ b/store/play-store-en.txt
@@ -43,7 +43,7 @@ Monthly view that groups your doses by day and status — pending, taken, skippe
 Keep all your upcoming and past medical appointments organized: doctor name, location with map pin, date/time, notes, and a configurable reminder (1 hour, 2 hours, or 1 day before).
 
 ▸ YOUR DATA IS YOURS — ALWAYS
-Your health data — medications, history, measurements, and diary — lives in a private local database and never leaves your device. The only exceptions: technical crash diagnostics (which never include your health data) and, if you add a location to an appointment, the map lookup. No account, no cloud sync, no usage analytics, no ads. Export a full backup (medications, history, appointments, health data, and diary) at any time and restore it if you switch phones.
+Your health data — medications, history, measurements, and diary — lives in a private local database and never leaves your device. The only exceptions: technical crash diagnostics (which never include your health data) and, if you add a location to an appointment, the map lookup. No account, no cloud sync, no usage analytics. The app is free, supported by unobtrusive banners on secondary screens only — never on your alarms or medication lists. Export a full backup (medications, history, appointments, health data, and diary) at any time and restore it if you switch phones.
 
 ▸ SPANISH & ENGLISH
 The app automatically detects your device language. Spanish and English are both fully supported, and you can switch languages manually from Settings at any time.

--- a/store/play-store-es.txt
+++ b/store/play-store-es.txt
@@ -43,7 +43,7 @@ Vista mensual que agrupa tus dosis por día y estado para identificar al instant
 Organizá todas tus citas médicas próximas y pasadas: nombre del médico, ubicación con pin en el mapa, fecha/hora, notas y recordatorio configurable (1 hora, 2 horas o 1 día antes).
 
 ▸ TUS DATOS SON TUYOS — SIEMPRE
-Tus datos de salud — medicamentos, historial, mediciones y diario — viven en una base de datos local privada y nunca salen de tu dispositivo. Las únicas excepciones: diagnósticos técnicos de fallos (que jamás incluyen tus datos de salud) y, si agregás la ubicación de una cita, la consulta al mapa. Sin cuenta, sin sincronización en la nube, sin analíticas de uso, sin anuncios. Exportá una copia de seguridad completa en cualquier momento y restaurala si cambiás de teléfono.
+Tus datos de salud — medicamentos, historial, mediciones y diario — viven en una base de datos local privada y nunca salen de tu dispositivo. Las únicas excepciones: diagnósticos técnicos de fallos (que jamás incluyen tus datos de salud) y, si agregás la ubicación de una cita, la consulta al mapa. Sin cuenta, sin sincronización en la nube, sin analíticas de uso. La app es gratuita y se sostiene con avisos discretos, solo en pantallas secundarias — nunca en tus alarmas ni en tu medicación. Exportá una copia de seguridad completa en cualquier momento y restaurala si cambiás de teléfono.
 
 ▸ DISPONIBLE EN ESPAÑOL E INGLÉS
 La app detecta el idioma de tu dispositivo — español e inglés con soporte completo — y podés cambiarlo desde Ajustes cuando quieras.


### PR DESCRIPTION
## Qué hace

**Enciende los banners** con los IDs reales de AdMob (app registrada hoy en tu cuenta, `giuliano.taliano1@gmail.com`, con dos bloques para reporting por pantalla):

- App ID: `ca-app-pub-6639820412660854~4363189908`
- `banner-history`: `…/2454231920` · `banner-health`: `…/4331400319`

## Detalles

- `getBannerUnitId(screen)`: unidades reales **solo en builds release**; dev e iOS siguen con los TEST ids de Google (clickear ads reales en desarrollo viola políticas de AdMob).
- Manifest persistente: App ID real + los 4 permisos de ad-identifier vuelven a mergear normalmente (verificado en el manifest final: `AD_ID` ×1, `ADSERVICES` ×3).
- Copy ES/EN: fuera el claim "sin anuncios" → redacción honesta ("gratuita, con avisos discretos solo en pantallas secundarias — nunca en tus alarmas ni medicación"). La ficha PT ya nació neutral.
- `app-ads.txt` publicado en `giulianotaliano.github.io/app-ads.txt` (repo de la landing).

## ⚠️ Acoplamiento de release

Este cambio **debe viajar junto** con las declaraciones de Play ("Anuncios: Sí" + "ID de publicidad: Sí" + Data safety) en el reenvío post-conversión de cuenta — está listado como paso manual restante en `ads.ts`. Los banners reales además no sirven impresiones hasta que AdMob verifique la app contra la tienda (post-producción); mientras tanto el componente falla cerrado y no muestra nada.

## Validación

Jest **307/307**, eslint limpio, tsc solo baseline, merge de manifest **BUILD SUCCESSFUL** con verificación del resultado final.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
