### PR TITLE
fix(storage): el bloqueo de app no se podía desactivar — MMKV v4 renombró delete(key) a remove(key)

### DIFF
--- a/__mocks__/react-native-mmkv.js
+++ b/__mocks__/react-native-mmkv.js
@@ -9,7 +9,7 @@ const createStorageInstance = () => {
   return {
     getString: jest.fn((key) => store.get(key)),
     set: jest.fn((key, value) => { store.set(key, value); }),
-    delete: jest.fn((key) => { store.delete(key); }),
+    remove: jest.fn((key) => store.delete(key)),
     contains: jest.fn((key) => store.has(key)),
     clearAll: jest.fn(() => { store.clear(); }),
     getAllKeys: jest.fn(() => Array.from(store.keys())),

--- a/__tests__/appLock.test.ts
+++ b/__tests__/appLock.test.ts
@@ -20,7 +20,7 @@ import { STORAGE_KEYS } from "../src/config";
 describe("appLock", () => {
   beforeEach(async () => {
     await disableAppLock();
-    storage.delete(STORAGE_KEYS.APP_LOCK_BIOMETRIC);
+    storage.remove(STORAGE_KEYS.APP_LOCK_BIOMETRIC);
   });
 
   it("is disabled by default with no PIN stored", async () => {

--- a/__tests__/snoozeSettings.test.ts
+++ b/__tests__/snoozeSettings.test.ts
@@ -13,7 +13,7 @@ import { STORAGE_KEYS } from "../src/config";
 
 describe("snoozeSettings", () => {
   beforeEach(() => {
-    storage.delete(STORAGE_KEYS.SNOOZE_MINUTES);
+    storage.remove(STORAGE_KEYS.SNOOZE_MINUTES);
   });
 
   it("falls back to DEFAULT_SNOOZE_MINUTES when unset", () => {

--- a/__tests__/timezone.test.ts
+++ b/__tests__/timezone.test.ts
@@ -6,7 +6,7 @@ import { storage } from "../src/storage";
 import { STORAGE_KEYS } from "../src/config";
 
 beforeEach(() => {
-  storage.delete(STORAGE_KEYS.LAST_TIMEZONE);
+  storage.remove(STORAGE_KEYS.LAST_TIMEZONE);
 });
 
 describe("detectTimezoneChange", () => {

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -281,7 +281,7 @@ export default function SettingsScreen() {
         showToast(t("appLock.pinChangedToast"), "success");
       }
     } catch {
-      showToast(t("settings.exportErrorGeneric"), "error");
+      showToast(t("appLock.errorGeneric"), "error");
     }
   };
 

--- a/docs/tech-improvements.md
+++ b/docs/tech-improvements.md
@@ -178,7 +178,7 @@ import { storage } from '../storage'
 const mmkvStorage = {
   getItem: (key: string) => storage.getString(key) ?? null,
   setItem: (key: string, value: string) => storage.set(key, value),
-  removeItem: (key: string) => storage.delete(key),
+  removeItem: (key: string) => storage.remove(key),
 }
 
 export const usePrefsStore = create(

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -694,6 +694,7 @@ const en: TranslationShape = {
     enabledToast: "App lock enabled",
     disabledToast: "App lock disabled",
     pinChangedToast: "PIN updated",
+    errorGeneric: "Could not update app lock. Try again.",
   },
   settings: {
     title: "Settings",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -692,6 +692,7 @@ const es = {
     enabledToast: "Bloqueo de app activado",
     disabledToast: "Bloqueo de app desactivado",
     pinChangedToast: "PIN actualizado",
+    errorGeneric: "No se pudo actualizar el bloqueo. Intentá de nuevo.",
   },
   settings: {
     title: "Ajustes",

--- a/src/i18n/pt.ts
+++ b/src/i18n/pt.ts
@@ -696,6 +696,7 @@ const pt: TranslationShape = {
     enabledToast: "Bloqueio do app ativado",
     disabledToast: "Bloqueio do app desativado",
     pinChangedToast: "PIN atualizado",
+    errorGeneric: "Não foi possível atualizar o bloqueio. Tente de novo.",
   },
   settings: {
     title: "Ajustes",

--- a/src/services/appLock.ts
+++ b/src/services/appLock.ts
@@ -78,7 +78,7 @@ export async function enableAppLock(pin: string): Promise<void> {
 
 /** Disables the lock and wipes the stored PIN hash. */
 export async function disableAppLock(): Promise<void> {
-  storage.delete(STORAGE_KEYS.APP_LOCK_ENABLED);
+  storage.remove(STORAGE_KEYS.APP_LOCK_ENABLED);
   await SecureStore.deleteItemAsync(PIN_HASH_KEY).catch(() => {});
   await SecureStore.deleteItemAsync(PIN_SALT_KEY).catch(() => {});
 }

--- a/src/services/healthSync.ts
+++ b/src/services/healthSync.ts
@@ -55,7 +55,7 @@ export async function enableHealthSync(): Promise<boolean> {
 }
 
 export function disableHealthSync(): void {
-  storage.delete(STORAGE_KEYS.HEALTH_SYNC);
+  storage.remove(STORAGE_KEYS.HEALTH_SYNC);
 }
 
 /**

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -12,9 +12,7 @@ function createFallbackStorage() {
     set: (key: string, value: string) => {
       store.set(key, value);
     },
-    delete: (key: string) => {
-      store.delete(key);
-    },
+    remove: (key: string) => store.delete(key),
     contains: (key: string) => store.has(key),
     clearAll: () => {
       store.clear();


### PR DESCRIPTION
## Qué pasaba

`react-native-mmkv` v4 (Nitro) renombró `delete(key)` a `remove(key)` — el spec en `node_modules/react-native-mmkv/src/specs/MMKV.nitro.ts:77` solo expone `remove(key: string): boolean`, `delete` no existe más. Todo call site de `storage.delete(...)` lanzaba `TypeError` en builds nativos.

**Por qué no lo vimos antes:** el bug solo aparece en builds nativos (release 1.7.0/vc24, confirmado en emulador). En Expo Go, `src/storage.ts` usa un fallback con `Map` que sí tenía `delete`, y el mock de Jest replicaba la API vieja de v3 — así que ni en desarrollo ni en tests fallaba nada.

**Efectos:**
1. **Crítico:** `disableAppLock()` tiraba siempre → el usuario **no podía desactivar el bloqueo de app nunca**. Verificaba el PIN, saltaba el TypeError y el toggle quedaba prendido.
2. Latente: `disableHealthSync()` tenía el mismo bug (se iba a manifestar al apagar el sync de Health Connect).
3. Encima, el `catch` de `handlePinSuccess` en settings mostraba un string equivocado, copy-paste del handler de export: "Não foi possível exportar. Tente de novo." — nada que ver con el bloqueo.

## Qué cambia

- **`src/storage.ts`**: el fallback de Expo Go ahora expone `remove` (espejo fiel de la API v4, devuelve `boolean` como el spec).
- **`src/services/appLock.ts`** y **`src/services/healthSync.ts`**: `storage.delete(...)` → `storage.remove(...)`.
- **`__mocks__/react-native-mmkv.js`**: el mock de Jest queda alineado a v4 — si alguien vuelve a escribir `storage.delete`, ahora rompe en tests en vez de romper solo en el build nativo.
- **`__tests__/`** (appLock, timezone, snoozeSettings): mismos renames en los `beforeEach`.
- **`app/(tabs)/settings.tsx`**: el catch de app lock ahora muestra la key nueva `appLock.errorGeneric`, agregada en es/en/pt ("No se pudo actualizar el bloqueo. Intentá de nuevo.").
- **`docs/tech-improvements.md`**: snippet propuesto de Zustand actualizado a `storage.remove`.

Revisé también el toggle de Health Connect en settings: no tiene catch propio (el error específico lo maneja `enableHealthSync` devolviendo `false` con su propio string `healthSyncDenied`), así que no había string equivocado que corregir ahí.

Verificado con grep: no queda ningún uso de `storage.delete` en el repo.

## Validación

- `npx tsc --noEmit`: salida idéntica al baseline de `main` (los errores preexistentes de `jest.setup.ts`/`pdfReport.ts` ya estaban; este PR no agrega ninguno).
- `npm test`: **28 suites, 307 tests, todos en verde.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
