### PR TITLE
fix(alarm): atribución de perfil en pantalla de alarma y plurales de dosis

### DIFF
--- a/__tests__/localizedDosage.test.ts
+++ b/__tests__/localizedDosage.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Long-form dosage pluralization + profile attribution (emulator findings
+ * on 1.7.0/vc24): the alarm co-due row and the emergency card rendered the
+ * raw `dosage` string ("1 comprimidos"), and the alarm screen never said
+ * WHOSE dose was ringing on multi-profile devices.
+ */
+import i18n, { initI18n } from "../src/i18n";
+import { getLocalizedDosageLong, getProfileLabel } from "../src/utils";
+import type { DosageUnit } from "../src/types";
+
+jest.mock("expo-localization", () => ({
+  getLocales: () => [{ languageCode: "es" }],
+}));
+
+beforeAll(() => initI18n());
+
+const t = ((key: string, opts?: Record<string, unknown>) => i18n.t(key, opts)) as any;
+
+const med = (dosageAmount: number, dosageUnit: DosageUnit) => ({ dosageAmount, dosageUnit });
+
+// ─── getLocalizedDosageLong ────────────────────────────────────────────────
+
+describe("getLocalizedDosageLong", () => {
+  it("pluralizes countable units in Spanish", async () => {
+    await i18n.changeLanguage("es");
+    expect(getLocalizedDosageLong(med(1, "comprimidos"), t)).toBe("1 comprimido");
+    expect(getLocalizedDosageLong(med(2, "comprimidos"), t)).toBe("2 comprimidos");
+    expect(getLocalizedDosageLong(med(1, "gotas"), t)).toBe("1 gota");
+    expect(getLocalizedDosageLong(med(3, "gotas"), t)).toBe("3 gotas");
+    expect(getLocalizedDosageLong(med(1, "capsulas"), t)).toBe("1 cápsula");
+    expect(getLocalizedDosageLong(med(2, "capsulas"), t)).toBe("2 cápsulas");
+  });
+
+  it("pluralizes countable units in Portuguese", async () => {
+    await i18n.changeLanguage("pt");
+    expect(getLocalizedDosageLong(med(1, "comprimidos"), t)).toBe("1 comprimido");
+    expect(getLocalizedDosageLong(med(3, "comprimidos"), t)).toBe("3 comprimidos");
+    expect(getLocalizedDosageLong(med(1, "gotas"), t)).toBe("1 gota");
+    expect(getLocalizedDosageLong(med(1, "capsulas"), t)).toBe("1 cápsula");
+  });
+
+  it("pluralizes countable units in English", async () => {
+    await i18n.changeLanguage("en");
+    expect(getLocalizedDosageLong(med(1, "comprimidos"), t)).toBe("1 tablet");
+    expect(getLocalizedDosageLong(med(2, "comprimidos"), t)).toBe("2 tablets");
+    expect(getLocalizedDosageLong(med(1, "gotas"), t)).toBe("1 drop");
+    expect(getLocalizedDosageLong(med(1, "capsulas"), t)).toBe("1 capsule");
+  });
+
+  it("passes metric units through untranslated", async () => {
+    await i18n.changeLanguage("es");
+    expect(getLocalizedDosageLong(med(500, "mg"), t)).toBe("500 mg");
+    expect(getLocalizedDosageLong(med(10, "ml"), t)).toBe("10 ml");
+    expect(getLocalizedDosageLong(med(1000, "UI"), t)).toBe("1000 UI");
+  });
+});
+
+// ─── getProfileLabel ───────────────────────────────────────────────────────
+
+describe("getProfileLabel", () => {
+  const multi = [
+    { id: "default", name: "" },
+    { id: "p2", name: "Mamá" },
+  ];
+
+  it("returns null with a single profile (no ambiguity)", () => {
+    expect(getProfileLabel({ profileId: "p2" }, [{ id: "p2", name: "Mamá" }], t)).toBeNull();
+  });
+
+  it("returns the owner's name with multiple profiles", () => {
+    expect(getProfileLabel({ profileId: "p2" }, multi, t)).toBe("Mamá");
+  });
+
+  it("falls back to localized 'Me' for the unnamed default profile", async () => {
+    await i18n.changeLanguage("es");
+    expect(getProfileLabel({ profileId: "default" }, multi, t)).toBe("Yo");
+  });
+
+  it("treats a med without profileId as owned by 'default'", async () => {
+    await i18n.changeLanguage("es");
+    expect(getProfileLabel({}, multi, t)).toBe("Yo");
+  });
+
+  it("returns null when the owning profile no longer exists", () => {
+    expect(getProfileLabel({ profileId: "ghost" }, multi, t)).toBeNull();
+  });
+});

--- a/app/alarm.tsx
+++ b/app/alarm.tsx
@@ -4,7 +4,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useRef, useState } from "react";
 import { useAppStore } from "../src/store";
-import { getColorConfig, formatTimeForDisplay, getLocalizedDosage, isScheduleActiveOnDate } from "../src/utils";
+import { getColorConfig, formatTimeForDisplay, getLocalizedDosageLong, getProfileLabel, isScheduleActiveOnDate } from "../src/utils";
 import { SNOOZE_OPTIONS, getDefaultSnoozeMinutes } from "../src/services/snoozeSettings";
 import { useTranslation } from "../src/i18n";
 import { stopAlarm, setAlarmWindowFlags, clearAlarmWindowFlags } from "expo-alarm";
@@ -54,6 +54,7 @@ export default function AlarmScreen() {
 
   const medications = useAppStore((s) => s.medications);
   const schedules = useAppStore((s) => s.schedules);
+  const profiles = useAppStore((s) => s.profiles);
   const isLoading = useAppStore((s) => s.isLoading);
   const markDose = useAppStore((s) => s.markDose);
   const snoozeDose = useAppStore((s) => s.snoozeDose);
@@ -96,7 +97,7 @@ export default function AlarmScreen() {
   useEffect(() => {
     if (action || !medication || spokeRef.current) return;
     spokeRef.current = true;
-    speakDoseReminder(medication.name, getLocalizedDosage(medication, t));
+    speakDoseReminder(medication.name, getLocalizedDosageLong(medication, t));
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [medication, action]);
 
@@ -171,6 +172,10 @@ export default function AlarmScreen() {
   if (!medication || !schedule || action) return null;
 
   const colors = getColorConfig(medication.color);
+  // Whose dose is this? Non-null only with 2+ profiles on the device (F2) —
+  // a caregiver juggling several regimens must see the owner on THIS screen,
+  // not just in the notification title.
+  const ownerLabel = getProfileLabel(medication, profiles, t);
 
   const dose = {
     medication,
@@ -265,9 +270,20 @@ export default function AlarmScreen() {
           </View>
         </Animated.View>
 
+        {/* Profile attribution (F2): with several regimens on the phone the
+            caregiver must see WHOSE dose is ringing, right next to the name. */}
+        {ownerLabel && (
+          <View
+            style={{ backgroundColor: colors.bg }}
+            className="mt-6 px-3 py-1 rounded-full flex-row items-center gap-1.5"
+          >
+            <Ionicons name="person" size={13} color="#ffffff" />
+            <Text className="text-sm font-bold text-white">{ownerLabel}</Text>
+          </View>
+        )}
         <Text
           style={{ color: colors.text }}
-          className="text-3xl font-black mt-6 text-center"
+          className={`text-3xl font-black text-center ${ownerLabel ? "mt-2" : "mt-6"}`}
         >
           {medication.name}
         </Text>
@@ -277,7 +293,7 @@ export default function AlarmScreen() {
           className="mt-2 px-4 py-1 rounded-full border"
         >
           <Text style={{ color: colors.text }} className="text-sm font-semibold text-center">
-            {getLocalizedDosage(medication, t)}
+            {getLocalizedDosageLong(medication, t)}
           </Text>
         </View>
         {medication.notes ? (
@@ -325,6 +341,7 @@ export default function AlarmScreen() {
           </Text>
           {coDue.map((co) => {
             const handled = handledCo[co.schedule.id];
+            const coOwner = getProfileLabel(co.medication, profiles, t);
             return (
               <View
                 key={co.schedule.id}
@@ -332,7 +349,7 @@ export default function AlarmScreen() {
                 className="flex-row items-center gap-2 rounded-2xl border px-3 py-2 mb-2"
               >
                 <Text className="flex-1 text-sm font-semibold" style={{ color: colors.text }} numberOfLines={1}>
-                  {co.medication.name} · {co.medication.dosage}
+                  {coOwner ? `${coOwner} · ` : ""}{co.medication.name} · {getLocalizedDosageLong(co.medication, t)}
                 </Text>
                 {handled ? (
                   <Ionicons

--- a/app/emergency.tsx
+++ b/app/emergency.tsx
@@ -20,6 +20,7 @@ import {
   getProfiles,
 } from "../src/db/database";
 import { getActiveProfileId } from "../src/services/profileStore";
+import { getLocalizedDosageLong } from "../src/utils";
 import type { Allergy, Medication, Profile } from "../src/types";
 
 export default function EmergencyScreen() {
@@ -105,7 +106,7 @@ export default function EmergencyScreen() {
           ) : (
             meds.map((m) => (
               <Text key={m.id} className="text-lg font-semibold text-text leading-7">
-                • {m.name} — {m.dosage}
+                • {m.name} — {getLocalizedDosageLong(m, t)}
               </Text>
             ))
           )}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -34,6 +34,16 @@ const en: TranslationShape = {
     capsulas: "caps.",
   },
 
+  // Full unit names for running text (alarm, emergency, TTS) — pluralized by amount.
+  dosageUnitsLong: {
+    gotas_one: "drop",
+    gotas_other: "drops",
+    comprimidos_one: "tablet",
+    comprimidos_other: "tablets",
+    capsulas_one: "capsule",
+    capsulas_other: "capsules",
+  },
+
   // ─── Categories ───────────────────────────────────────────────────────────
   categories: {
     antibiotico: "Antibiotic",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -32,6 +32,16 @@ const es = {
     capsulas: "cáps.",
   },
 
+  // Full unit names for running text (alarm, emergency, TTS) — pluralized by amount.
+  dosageUnitsLong: {
+    gotas_one: "gota",
+    gotas_other: "gotas",
+    comprimidos_one: "comprimido",
+    comprimidos_other: "comprimidos",
+    capsulas_one: "cápsula",
+    capsulas_other: "cápsulas",
+  },
+
   // ─── Categories ───────────────────────────────────────────────────────────
   categories: {
     antibiotico: "Antibiótico",

--- a/src/i18n/pt.ts
+++ b/src/i18n/pt.ts
@@ -34,6 +34,16 @@ const pt: TranslationShape = {
     capsulas: "cáps.",
   },
 
+  // Full unit names for running text (alarm, emergency, TTS) — pluralized by amount.
+  dosageUnitsLong: {
+    gotas_one: "gota",
+    gotas_other: "gotas",
+    comprimidos_one: "comprimido",
+    comprimidos_other: "comprimidos",
+    capsulas_one: "cápsula",
+    capsulas_other: "cápsulas",
+  },
+
   // ─── Categories ───────────────────────────────────────────────────────────
   categories: {
     antibiotico: "Antibiótico",

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -5,7 +5,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Platform } from "react-native";
 import { addDays, addMinutes, format, startOfDay } from "date-fns";
 import { Schedule, Medication, NotificationMap, Appointment } from "../types";
-import { parseTime, isScheduleActiveOnDate, getNextDates, toDateString, getLocalizedDosage } from "../utils";
+import { parseTime, isScheduleActiveOnDate, getNextDates, toDateString, getLocalizedDosage, getProfileLabel } from "../utils";
 import i18n from "../i18n";
 import { STORAGE_KEYS } from "../config";
 import { getDefaultSnoozeMinutes as getSnoozeMin } from "./snoozeSettings";
@@ -332,11 +332,8 @@ export async function getNotifMapEntry(
 async function medDisplayName(med: Medication): Promise<string> {
   try {
     const profiles = await getProfiles();
-    if (profiles.length <= 1) return med.name;
-    const p = profiles.find((x) => x.id === (med.profileId ?? "default"));
-    if (!p) return med.name;
-    const who = p.name || (i18n.t("profiles.me") as string);
-    return `${who} · ${med.name}`;
+    const who = getProfileLabel(med, profiles, i18n.t.bind(i18n));
+    return who ? `${who} · ${med.name}` : med.name;
   } catch {
     return med.name;
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -130,6 +130,40 @@ export function getLocalizedDosage(med: { dosageAmount: number; dosageUnit: Dosa
   return `${med.dosageAmount} ${getDosageLabel(med.dosageUnit, t)}`;
 }
 
+/**
+ * Like getLocalizedDosage but with the FULL unit name, singular/plural by
+ * amount ("1 comprimido" / "2 comprimidos"). For surfaces read as running
+ * text — alarm screen, emergency card, TTS — where "1 comp." is cryptic and
+ * a fixed-plural "1 comprimidos" is wrong.
+ */
+export function getLocalizedDosageLong(med: { dosageAmount: number; dosageUnit: DosageUnit }, t: TFunction): string {
+  const countable: Partial<Record<DosageUnit, string>> = {
+    gotas:       "gotas",
+    comprimidos: "comprimidos",
+    capsulas:    "capsulas",
+  };
+  const key = countable[med.dosageUnit];
+  if (!key) return `${med.dosageAmount} ${med.dosageUnit}`;
+  return `${med.dosageAmount} ${t(`dosageUnitsLong.${key}`, { count: med.dosageAmount })}`;
+}
+
+/**
+ * Multi-profile attribution (F2): whose med is this? Returns the owning
+ * profile's display name, or null when the device has a single profile —
+ * with no ambiguity the label is just clutter. Mirrors medDisplayName in
+ * services/notifications.ts so screens and notifications agree.
+ */
+export function getProfileLabel(
+  med: { profileId?: string },
+  profiles: { id: string; name: string }[],
+  t: TFunction
+): string | null {
+  if (profiles.length <= 1) return null;
+  const p = profiles.find((x) => x.id === (med.profileId ?? "default"));
+  if (!p) return null;
+  return p.name || (t("profiles.me") as string);
+}
+
 /** Color palette for preset medication colors */
 export const MEDICATION_COLORS: Record<string, { bg: string; light: string; text: string; border: string }> = {
   blue:   { bg: "#3b82f6", light: "#dbeafe", text: "#1d4ed8", border: "#93c5fd" },


### PR DESCRIPTION
## Resumen

Arregla dos hallazgos de la validación en emulador de 1.7.0/vc24 sobre la pantalla de alarma full-screen (`app/alarm.tsx`):

### 1. Falta de atribución de perfil (multi-perfil, F2)

La pantalla de alarma mostraba `medication.name` pelado (p.ej. "Enalapril") sin decir de quién es la dosis. El helper `medDisplayName` que antepone "Mamá · " solo llegaba a los payloads de las notificaciones nativas — un cuidador con varios regímenes en el teléfono no sabía de quién era la dosis en la pantalla más importante.

- Nuevo helper `getProfileLabel(med, profiles, t)` en `src/utils`: devuelve el nombre del perfil dueño solo cuando hay 2+ perfiles en el dispositivo (con uno solo no hay ambigüedad y la etiqueta es ruido). El perfil default sin nombre cae al "Yo"/"Me"/"Eu" localizado.
- La pantalla de alarma ahora renderiza un chip con ícono de persona + nombre del perfil arriba del nombre del med.
- Las filas de "También a esta hora" (co-due) llevan el prefijo `Perfil · ` — esas dosis pueden ser de otros perfiles porque la pantalla resuelve meds de toda la DB.
- `medDisplayName` en `notifications.ts` ahora delega en `getProfileLabel`: una sola fuente de verdad, pantallas y notificaciones siempre de acuerdo.

### 2. Pluralización de unidades de dosis

La fila co-due y la ficha de emergencia renderizaban el string crudo `medication.dosage`, que concatena el valor de unidad fijo en plural: "1 comprimidos" en los tres idiomas.

- Nuevo `getLocalizedDosageLong(med, t)`: nombre completo de unidad pluralizado por cantidad vía i18next (`_one`/`_other`) para las unidades contables (comprimidos, cápsulas, gotas); las métricas (mg, ml, UI…) pasan sin tocar.
- Claves nuevas `dosageUnitsLong` en es/en/pt: "1 comprimido" / "2 comprimidos", "1 tablet" / "2 tablets".
- Lo usan: la fila co-due, la ficha de emergencia, la pastilla de dosis de la alarma y el recordatorio hablado (TTS), que antes leía "1 comp." en voz alta.
- El selector de unidades del formulario sigue usando las abreviaturas (`getDosageLabel`) — sin cambios ahí.

## Tests

- Suite nueva `__tests__/localizedDosage.test.ts` con i18n real: singular/plural en es/pt/en, unidades métricas pass-through, y las reglas de `getProfileLabel` (un solo perfil → null, default sin nombre → "Yo", perfil inexistente → null).
- `npm test`: **316 tests pasan** (307 previos + 9 nuevos), 29 suites.
- `npx tsc --noEmit`: idéntico al baseline de `main` — este cambio no agrega ningún error (los existentes en `__tests__/` por falta de `@types/jest` son pre-existentes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)