### PR TITLE
chore(release): bump versionCode to 25 (1.7.0)

### DIFF
--- a/app.json
+++ b/app.json
@@ -31,7 +31,7 @@
     },
     "android": {
       "package": "com.pilloclock.app",
-      "versionCode": 24,
+      "versionCode": 25,
       "adaptiveIcon": {
         "backgroundColor": "#f0f6ff",
         "foregroundImage": "./assets/android-icon-foreground.png",


### PR DESCRIPTION
Sube el `versionCode` de Android a **25** en `app.json` (el `build.gradle` local, gitignoreado, ya está en 25).

**Por qué:** vc24 quedó consumido como release pendiente en el track alpha. vc25 incorpora los fixes ya mergeados:
- **#115** — `storage.remove` (MMKV v4): el bloqueo de app volvía a ser desactivable (antes tiraba `TypeError`).
- **#116** — atribución de perfil en la pantalla de alarma + pluralización de dosis (`getLocalizedDosageLong`).

**Validación:** los 3 findings re-validados en emulador (Pixel_9, APK release vc25): app lock activar→desactivar OK sin `TypeError`; chip `👤 perfil` en la alarma con 2+ perfiles; dosis renderiza `1 tablet` (singular).

🤖 Generated with [Claude Code](https://claude.com/claude-code)