### PR TITLE
fix(db): no crashear al migrar desde una DB pre-perfiles (v13) + vc26

### DIFF
--- a/app.json
+++ b/app.json
@@ -31,7 +31,7 @@
     },
     "android": {
       "package": "com.pilloclock.app",
-      "versionCode": 24,
+      "versionCode": 26,
       "adaptiveIcon": {
         "backgroundColor": "#f0f6ff",
         "foregroundImage": "./assets/android-icon-foreground.png",

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -383,10 +383,14 @@ export async function initDatabase(): Promise<void> {
       created_at  TEXT NOT NULL,
       profile_id  TEXT NOT NULL DEFAULT 'default'
     );
-
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_checkin_profile_date
-      ON daily_checkins(profile_id, date);
   `);
+  // NOTE: idx_checkin_profile_date (on daily_checkins.profile_id) is created by
+  // the v14 migration below, NOT here. On an upgrade from a pre-multi-profile
+  // DB (user_version < 14) the daily_checkins table already exists WITHOUT
+  // profile_id, so `CREATE TABLE IF NOT EXISTS` is a no-op and a profile_id
+  // index in this upfront block would throw "no such column: profile_id" and
+  // brick startup. v14 adds the column (rebuilding the table) and then creates
+  // the index — and v14 always runs on fresh installs too (user_version 0 < 14).
 
   const [{ user_version }] = expoDb.getAllSync<{ user_version: number }>(
     "PRAGMA user_version"


### PR DESCRIPTION
## Bug (reportado en un update real 1.6.1 → 1.7.0 en prueba interna)

Al abrir la app tras actualizar desde 1.6.1, crash de arranque:

> `Call to function 'NativeDatabase.execSync' has been rejected. → Caused by: no such column: profile_id`

## Causa

El bloque DDL de arranque de `initDatabase()` creaba el índice único `idx_checkin_profile_date` sobre `daily_checkins(profile_id, date)` **antes** de que la migración **v14** agregue la columna `profile_id`. En instalación fresca la tabla se crea con la columna, pero al **actualizar** desde una DB sin perfiles (`user_version < 14`) `daily_checkins` ya existe **sin** `profile_id`, el `CREATE TABLE IF NOT EXISTS` es no-op, y el `CREATE INDEX` explota → `_layout` captura el error y muestra la pantalla de error, app inutilizable.

No se detectó en el emulador porque ahí la DB era fresca (o restaurada de un build que ya tenía `profile_id`); sólo se manifiesta en un **upgrade real v13→v18** con datos previos.

## Fix

El índice se crea únicamente en la migración v14 (que primero agrega/reconstruye la columna). v14 también corre en instalaciones frescas (`user_version 0 < 14`), así que no se pierde en ese caso.

**Verificado con SQLite puro** (repro del crash + del fix): una DB v13 con datos migra a v14+ preservando los check-ins/medicaciones, con `profile_id` e índice presentes, y el `SELECT profile_id` deja de crashear. La app en el teléfono del reporter quedó a medio migrar (user_version 13, `profiles`/`allergies` creadas); vc26 la recupera limpio (v14 completa lo que falta).

## Follow-up

No hay harness de SQL en los tests (mockean el módulo DB; `better-sqlite3` no está instalado), así que no se pudo agregar un test de regresión automatizado. Sería valioso montar uno (better-sqlite3 o node:sqlite) para cubrir migraciones.

Bump a **versionCode 26** (vc25 quedó consumido en interna/alpha). Supersede el bump de #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)