### PR TITLE
fix(medform): el input de nombre ya no pierde el foco por cada tecla

### DIFF
--- a/components/MedicationForm.tsx
+++ b/components/MedicationForm.tsx
@@ -1296,9 +1296,17 @@ export function MedicationForm({
     ? [SlideIdentity, SlideFrequency, SlideExtras, SlideAppearance]
     : [SlideIdentity, SlideFrequency, SlideAlarms, SlideExtras, SlideAppearance];
 
-  const renderSlide = useCallback(({ item: SlideComponent, index }: { item: () => React.JSX.Element; index: number }) => (
+  // Render the slide by CALLING the function, not as `<SlideComponent />`.
+  // These slide functions are re-declared on every parent render, so mounting
+  // them as JSX elements gives each a new component *type* every render — React
+  // then unmounts and remounts the whole subtree on any state change (e.g. the
+  // per-keystroke drug-suggestion update), which yanked focus out of the name
+  // TextInput on every character. Calling the function returns a stable-typed
+  // element tree that reconciles by position, so focus is preserved. Safe
+  // because no Slide* function calls hooks.
+  const renderSlide = useCallback(({ item: renderSlideContent }: { item: () => React.JSX.Element; index: number }) => (
     <View style={{ width: screenWidth }}>
-      <SlideComponent />
+      {renderSlideContent()}
     </View>
   ), [screenWidth]);
 


### PR DESCRIPTION
## Síntoma (reportado desde dispositivo)

En el alta de medicamento, el campo **Nombre** perdía el foco del teclado en cada carácter tecleado o borrado, haciendo el tipeo engorroso.

## Causa

Los slides del wizard (`SlideIdentity`, `SlideFrequency`, …) están declarados **dentro** del cuerpo del componente `MedicationForm` y se renderizaban como `<SlideComponent />` (componente). Como esas funciones se re-declaran en cada render, cada una adquiere una **identidad de tipo nueva** por render → React desmonta y re-monta todo el subárbol del slide ante cualquier cambio de estado. La actualización de sugerencias en `onChangeText` (`setDrugSuggestions(searchDrugs(v))`) dispara ese re-render en cada pulsación → el `TextInput` se re-monta → pierde el foco.

## Fix

Renderizar el slide **llamando la función** (`{renderSlideContent()}`) en vez de instanciarla como elemento. Esto devuelve un árbol de elementos de tipo estable (View/ScrollView/TextInput en posiciones fijas) que React reconcilia por posición → el foco se preserva. Seguro porque **ningún** `Slide*` llama hooks (verificado).

Tests: 45/45 del área (drugDb, barcode, medicationsSlice) verdes; `MedicationForm` type-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)